### PR TITLE
Fix fork handling in BlockProcessor

### DIFF
--- a/backend/src/main/kotlin/xyz/funkybit/core/model/db/Block.kt
+++ b/backend/src/main/kotlin/xyz/funkybit/core/model/db/Block.kt
@@ -5,6 +5,7 @@ import org.jetbrains.exposed.dao.EntityClass
 import org.jetbrains.exposed.dao.id.EntityID
 import org.jetbrains.exposed.sql.SortOrder
 import org.jetbrains.exposed.sql.and
+import org.web3j.protocol.core.methods.response.EthBlock
 import java.math.BigInteger
 
 @Serializable
@@ -25,6 +26,9 @@ object BlockTable : GUIDTable<BlockHash>("block", ::BlockHash) {
 
 class BlockEntity(guid: EntityID<BlockHash>) : GUIDEntity<BlockHash>(guid) {
     companion object : EntityClass<BlockHash, BlockEntity>(BlockTable) {
+        fun create(blockFromRpcNode: EthBlock.Block, chainId: ChainId): BlockEntity =
+            create(BlockHash(blockFromRpcNode.hash), blockFromRpcNode.number, BlockHash(blockFromRpcNode.parentHash), chainId)
+
         fun create(hash: BlockHash, number: BigInteger, parentHash: BlockHash, chainId: ChainId): BlockEntity =
             BlockEntity.new(hash) {
                 this.number = number
@@ -49,4 +53,7 @@ class BlockEntity(guid: EntityID<BlockHash>) : GUIDEntity<BlockHash>(guid) {
         toReal = ::BlockHash,
         toColumn = { it.value },
     )
+
+    val hash: String
+        get() = guid.value.value
 }


### PR DESCRIPTION
- `BlockProcessor` has an infinite loop where it calculates a sequence for block numbers to process based on the latest block stored in DB and latest block number returned from RPC node
- In that loop it would iterate over block numbers and for each block number it would fetch the block from RPC node and check if its parent hash equals to the hash of previous block in our DB, if yes - we would process the block and store it, otherwise that's a fork
- Fork handling was done incorrectly before this PR - we would rollback blocks until forking point and then continue block processing from the same place which is wrong. E.g: had a sequence of blocks 1..10 to process, on block 5 detected a fork, rolled back to block 3 and then continued processing from block 6 which obviously leads to another (false) fork detection alert and it continues forever.
- In this PR I've added the logic to break from the loop once we have handled the fork