### PR TITLE
Disable Bitcoin in integration tests workflow because it is not deployed yet

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -42,6 +42,7 @@ jobs:
           EVM_NETWORK_URL_anvil: https://test-anvil.funkybit.fun
           EVM_NETWORK_URL_anvil2: https://test-anvil2.funkybit.fun
           INTEGRATION_RUN: 1
+          BITCOIN_NETWORK_ENABLED: "false"
           API_URL: https://test-api.funkybit.fun
           CI_RUN: 1
           SEQUENCER_HOST_NAME: test-sequencer.funkybit.fun


### PR DESCRIPTION
`AppUnderTestRunner` thinks it is enabled and timeouts while waiting for Arch program to be deployed:

https://github.com/funkybit-labs/chainring-monorepo/blob/main/integrationtests/src/test/kotlin/xyz/funkybit/integrationtests/testutils/AppUnderTestRunner.kt#L145-L157