### PR TITLE
Reduce tests flakiness

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -41,7 +41,7 @@ jobs:
           EVM_CHAINS: anvil,anvil2
           EVM_NETWORK_URL_anvil: https://test-anvil.funkybit.fun
           EVM_NETWORK_URL_anvil2: https://test-anvil2.funkybit.fun
-          INTEGRATION_RUN: 1
+          TEST_ENV_RUN: 1
           BITCOIN_NETWORK_ENABLED: "false"
           API_URL: https://test-api.funkybit.fun
           CI_RUN: 1

--- a/backend/src/main/kotlin/xyz/funkybit/apps/ring/BlockProcessor.kt
+++ b/backend/src/main/kotlin/xyz/funkybit/apps/ring/BlockProcessor.kt
@@ -112,7 +112,7 @@ class BlockProcessor(
     }
 
     private val blocksNumberToCheckOnForkDetected =
-        BigInteger.valueOf((System.getenv("BLOCKCHAIN_DEPOSIT_HANDLER_NUM_CONFIRMATIONS")?.toLongOrNull() ?: 1) + 1)
+        BigInteger.valueOf((System.getenv("BLOCKCHAIN_DEPOSIT_HANDLER_NUM_CONFIRMATIONS")?.toIntOrNull() ?: BlockchainDepositHandler.DEFAULT_NUM_CONFIRMATIONS) + 1L)
 
     private fun handleFork(blockFromRpcNode: EthBlock.Block, lastProcessedBlock: BlockEntity) {
         logger.error { "Fork detected: for block [height=${blockFromRpcNode.number},hash=${blockFromRpcNode.hash},parentHash=${blockFromRpcNode.parentHash}] latest block found in db is [height=${lastProcessedBlock.number},hash=${lastProcessedBlock.guid.value},parentHash=${lastProcessedBlock.parentGuid.value}]. Looking for split point starting at ${blockFromRpcNode.number}, chainId=$chainId" }

--- a/backend/src/main/kotlin/xyz/funkybit/apps/ring/BlockchainDepositHandler.kt
+++ b/backend/src/main/kotlin/xyz/funkybit/apps/ring/BlockchainDepositHandler.kt
@@ -24,10 +24,14 @@ import kotlin.time.Duration.Companion.minutes
 class BlockchainDepositHandler(
     private val blockchainClient: BlockchainClient,
     private val sequencerClient: SequencerClient,
-    private val numConfirmations: Int = System.getenv("BLOCKCHAIN_DEPOSIT_HANDLER_NUM_CONFIRMATIONS")?.toIntOrNull() ?: 1,
+    private val numConfirmations: Int = System.getenv("BLOCKCHAIN_DEPOSIT_HANDLER_NUM_CONFIRMATIONS")?.toIntOrNull() ?: DEFAULT_NUM_CONFIRMATIONS,
     private val pollingIntervalInMs: Long = System.getenv("BLOCKCHAIN_DEPOSIT_HANDLER_POLLING_INTERVAL_MS")?.toLongOrNull() ?: 500L,
     private val receiptMaxWaitTime: Duration = System.getenv("BLOCKCHAIN_DEPOSIT_HANDLER_RECEIPT_MAX_WAIT_TIME_MS")?.toLongOrNull()?.milliseconds ?: 10.minutes,
 ) {
+    companion object {
+        const val DEFAULT_NUM_CONFIRMATIONS: Int = 2
+    }
+
     private val chainId = blockchainClient.chainId
     private var workerThread: Thread? = null
     val logger = KotlinLogging.logger {}

--- a/backend/src/main/kotlin/xyz/funkybit/apps/ring/RingApp.kt
+++ b/backend/src/main/kotlin/xyz/funkybit/apps/ring/RingApp.kt
@@ -11,6 +11,7 @@ import xyz.funkybit.core.sequencer.SequencerClient
 
 data class RingAppConfig(
     val dbConfig: DbConfig = DbConfig(),
+    val repeaterAutomaticTaskScheduling: Boolean = System.getenv("REPEATER_AUTOMATIC_TASK_SCHEDULING")?.toBoolean() ?: true,
 )
 
 class RingApp(config: RingAppConfig = RingAppConfig()) : BaseApp(config.dbConfig) {
@@ -21,7 +22,7 @@ class RingApp(config: RingAppConfig = RingAppConfig()) : BaseApp(config.dbConfig
     private val chainWorkers = blockchainClients.map { ChainWorker(it, sequencerClient) }
     private val settlementCoordinator = SettlementCoordinator(blockchainClients, sequencerClient)
 
-    private val repeater = Repeater(db)
+    private val repeater = Repeater(db, config.repeaterAutomaticTaskScheduling)
 
     override fun start() {
         logger.info { "Starting" }

--- a/backend/src/main/kotlin/xyz/funkybit/core/repeater/Repeater.kt
+++ b/backend/src/main/kotlin/xyz/funkybit/core/repeater/Repeater.kt
@@ -8,7 +8,7 @@ import xyz.funkybit.core.utils.PgListener
 import java.util.concurrent.ScheduledThreadPoolExecutor
 import java.util.concurrent.TimeUnit
 
-class Repeater(db: Database) {
+class Repeater(db: Database, val automaticTaskScheduling: Boolean = true) {
     private val logger = KotlinLogging.logger {}
 
     private val tasks = mapOf(
@@ -38,8 +38,10 @@ class Repeater(db: Database) {
 
     fun start() {
         logger.info { "Starting" }
-        tasks.values.forEach {
-            it.schedule(timer)
+        if (automaticTaskScheduling) {
+            tasks.values.forEach {
+                it.schedule(timer)
+            }
         }
         pgListener.start()
         logger.info { "Started" }

--- a/backend/src/main/kotlin/xyz/funkybit/core/repeater/tasks/GasMonitorTask.kt
+++ b/backend/src/main/kotlin/xyz/funkybit/core/repeater/tasks/GasMonitorTask.kt
@@ -1,39 +1,54 @@
 package xyz.funkybit.core.repeater.tasks
 
 import io.github.oshai.kotlinlogging.KotlinLogging
+import org.jetbrains.exposed.sql.transactions.transaction
 import xyz.funkybit.core.blockchain.ChainManager
 import xyz.funkybit.core.model.db.ChainId
+import xyz.funkybit.core.model.db.KeyValueStore
 import java.math.BigInteger
 import kotlin.time.Duration.Companion.seconds
 
-val warned = mutableSetOf<ChainId>()
-
-class GasMonitorTask() : RepeaterBaseTask(
+class GasMonitorTask : RepeaterBaseTask(
     invokePeriod = 30.seconds,
 ) {
     val logger = KotlinLogging.logger {}
 
     private var minimumGasUnitsOverride: BigInteger? = null
+
     override fun setNextInvocationArgs(args: List<String>) {
         minimumGasUnitsOverride = args.first().toBigInteger()
     }
+
     override fun runWithLock() {
         ChainManager.getBlockchainClients().forEach {
             // set minimum amount to be equivalent to minimum gas units (or 100,000,000 if not specified) at the max
             // priority fee, as this scales well with the actual gas needed
             val minimumGas = (minimumGasUnitsOverride ?: BigInteger.valueOf(100_000_000L)) * it.gasProvider.getMaxPriorityFeePerGas(null)
             val availableGas = it.getNativeBalance(it.submitterAddress)
-            if (availableGas < minimumGas) {
-                if (!warned.contains(it.chainId)) {
-                    logger.error {
-                        "Low gas alert for submitter ${it.submitterAddress} on ${it.chainId}: only $availableGas available, need a minimum of $minimumGas"
+
+            transaction {
+                if (availableGas < minimumGas) {
+                    if (!isWarned(it.chainId)) {
+                        logger.error {
+                            "Low gas alert for submitter ${it.submitterAddress} on ${it.chainId}: only $availableGas available, need a minimum of $minimumGas"
+                        }
+                        setWarned(it.chainId, true)
                     }
-                    warned.add(it.chainId)
+                } else {
+                    setWarned(it.chainId, false)
                 }
-            } else {
-                warned.remove(it.chainId)
             }
         }
         minimumGasUnitsOverride = null
     }
+
+    private fun isWarned(chainId: ChainId): Boolean =
+        KeyValueStore.getBoolean(warnedFlagStorageKey(chainId))
+
+    private fun setWarned(chainId: ChainId, value: Boolean) {
+        KeyValueStore.setBoolean(warnedFlagStorageKey(chainId), value)
+    }
+
+    private fun warnedFlagStorageKey(chainId: ChainId): String =
+        "GasMonitorWarned:${chainId.value}"
 }

--- a/backend/src/test/kotlin/xyz/funkybit/testutils/TestWithDb.kt
+++ b/backend/src/test/kotlin/xyz/funkybit/testutils/TestWithDb.kt
@@ -43,12 +43,11 @@ import java.lang.System.getenv
 open class TestWithDb {
     companion object {
         private val logger = KotlinLogging.logger {}
-        private val isIntegrationRun = (getenv("INTEGRATION_RUN") ?: "0") == "1"
 
         @JvmStatic
         @BeforeAll
         fun beforeAll() {
-            Assumptions.assumeFalse(isIntegrationRun)
+            Assumptions.assumeFalse(isTestEnvRun())
             val db = Database.connect(DbConfig(port = 5433))
             db.upgrade(migrations, logger)
             TransactionManager.defaultDatabase = db
@@ -87,3 +86,6 @@ open class TestWithDb {
         }
     }
 }
+
+fun isTestEnvRun(): Boolean =
+    (getenv("TEST_ENV_RUN") ?: "0") == "1"

--- a/integrationtests/src/main/kotlin/xyz/funkybit/integrationtests/utils/Faucet.kt
+++ b/integrationtests/src/main/kotlin/xyz/funkybit/integrationtests/utils/Faucet.kt
@@ -1,6 +1,7 @@
 package xyz.funkybit.integrationtests.utils
 
 import org.web3j.protocol.core.methods.response.TransactionReceipt
+import xyz.funkybit.apps.ring.BlockchainDepositHandler
 import xyz.funkybit.core.blockchain.ChainManager
 import xyz.funkybit.core.model.Address
 import xyz.funkybit.core.model.db.ChainId
@@ -18,7 +19,9 @@ object Faucet {
     fun fundAndMine(address: Address, amount: BigInteger? = null, chainId: ChainId? = null): TransactionReceipt {
         return blockchainClient(chainId).let { client ->
             val txHash = client.sendNativeDepositTx(address, amount ?: BigDecimal("0.05").toFundamentalUnits(18))
-            client.mine()
+            repeat(BlockchainDepositHandler.DEFAULT_NUM_CONFIRMATIONS) {
+                client.mine()
+            }
             client.getTransactionReceipt(txHash)!!
         }
     }

--- a/integrationtests/src/main/kotlin/xyz/funkybit/integrationtests/utils/TestBlockchainClient.kt
+++ b/integrationtests/src/main/kotlin/xyz/funkybit/integrationtests/utils/TestBlockchainClient.kt
@@ -17,6 +17,7 @@ import xyz.funkybit.core.blockchain.ContractType
 import xyz.funkybit.core.model.Address
 import xyz.funkybit.core.model.TxHash
 import java.math.BigInteger
+import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 import kotlin.time.toJavaDuration
@@ -81,9 +82,9 @@ class TestBlockchainClient(blockchainConfig: BlockchainClientConfig) : Blockchai
             VoidResponse::class.java,
         ).send()
 
-    fun setIntervalMining(interval: Int = 1): VoidResponse = Request(
+    fun setIntervalMining(interval: Duration = 1.seconds): VoidResponse = Request(
         "evm_setIntervalMining",
-        listOf(interval),
+        listOf(interval.inWholeSeconds),
         web3jService,
         VoidResponse::class.java,
     ).send()

--- a/integrationtests/src/main/kotlin/xyz/funkybit/integrationtests/utils/Wallet.kt
+++ b/integrationtests/src/main/kotlin/xyz/funkybit/integrationtests/utils/Wallet.kt
@@ -13,6 +13,7 @@ import xyz.funkybit.apps.api.model.CreateOrderApiRequest
 import xyz.funkybit.apps.api.model.CreateWithdrawalApiRequest
 import xyz.funkybit.apps.api.model.OrderAmount
 import xyz.funkybit.apps.api.model.SymbolInfo
+import xyz.funkybit.apps.ring.BlockchainDepositHandler
 import xyz.funkybit.core.blockchain.ChainManager
 import xyz.funkybit.core.blockchain.ContractType
 import xyz.funkybit.core.evm.EIP712Helper
@@ -152,7 +153,7 @@ class Wallet(
             ),
         )
         val blockchainClient = blockchainClientsByChainId.getValue(currentChainId)
-        blockchainClient.mine()
+        blockchainClient.mine(BlockchainDepositHandler.DEFAULT_NUM_CONFIRMATIONS)
         return blockchainClient.getTransactionReceipt(txHash)!!
     }
 

--- a/integrationtests/src/test/kotlin/xyz/funkybit/integrationtests/api/ConfigRouteTest.kt
+++ b/integrationtests/src/test/kotlin/xyz/funkybit/integrationtests/api/ConfigRouteTest.kt
@@ -17,6 +17,7 @@ import xyz.funkybit.core.model.db.NetworkType
 import xyz.funkybit.core.model.db.SymbolEntity
 import xyz.funkybit.core.utils.toFundamentalUnits
 import xyz.funkybit.integrationtests.testutils.AppUnderTestRunner
+import xyz.funkybit.integrationtests.testutils.isTestEnvRun
 import xyz.funkybit.integrationtests.utils.TestApiClient
 import xyz.funkybit.tasks.fixtures.toChainSymbol
 import java.math.BigDecimal
@@ -64,7 +65,7 @@ class ConfigRouteTest {
 
     @Test
     fun testBitcoinConfiguration() {
-        Assumptions.assumeTrue((System.getenv("INTEGRATION_RUN") ?: "0") != "1")
+        Assumptions.assumeFalse(isTestEnvRun())
 
         val apiClient = TestApiClient()
 

--- a/integrationtests/src/test/kotlin/xyz/funkybit/integrationtests/api/WithdrawalTest.kt
+++ b/integrationtests/src/test/kotlin/xyz/funkybit/integrationtests/api/WithdrawalTest.kt
@@ -181,7 +181,7 @@ class WithdrawalTest {
                 ),
             )
 
-            waitForFinalizedWithdrawal(pendingUsdcWithdrawal.id)
+            waitForFinalizedWithdrawal(pendingUsdcWithdrawal.id, WithdrawalStatus.Complete)
 
             val usdcWithdrawal = apiClient.getWithdrawal(pendingUsdcWithdrawal.id).withdrawal
             assertEquals(WithdrawalStatus.Complete, usdcWithdrawal.status)
@@ -211,7 +211,7 @@ class WithdrawalTest {
                 ),
             ).withdrawal
             assertEquals(WithdrawalStatus.Pending, pendingUsdcWithdrawal2.status)
-            waitForFinalizedWithdrawal(pendingUsdcWithdrawal2.id)
+            waitForFinalizedWithdrawal(pendingUsdcWithdrawal2.id, WithdrawalStatus.Failed)
             val usdcWithdrawal2 = apiClient.getWithdrawal(pendingUsdcWithdrawal2.id).withdrawal
             assertEquals(WithdrawalStatus.Failed, usdcWithdrawal2.status)
             assertEquals("Insufficient Balance", usdcWithdrawal2.error)
@@ -332,7 +332,7 @@ class WithdrawalTest {
         val newDepositAmount = AssetAmount(usdc, "100")
         wallet.depositAndMine(newDepositAmount)
 
-        waitForFinalizedWithdrawal(pendingUsdcWithdrawal.id)
+        waitForFinalizedWithdrawal(pendingUsdcWithdrawal.id, WithdrawalStatus.Complete)
         val usdcWithdrawal = apiClient.getWithdrawal(pendingUsdcWithdrawal.id).withdrawal
         assertEquals(WithdrawalStatus.Complete, usdcWithdrawal.status)
         assertEquals(initialDepositAmount.inFundamentalUnits, usdcWithdrawal.amount)
@@ -392,7 +392,7 @@ class WithdrawalTest {
             ),
         )
 
-        waitForFinalizedWithdrawal(pendingUsdcWithdrawal.id)
+        waitForFinalizedWithdrawal(pendingUsdcWithdrawal.id, WithdrawalStatus.Complete)
 
         waitForBalance(
             apiClient,
@@ -406,7 +406,7 @@ class WithdrawalTest {
             WithdrawalEntity[pendingUsdcWithdrawal.id].status = WithdrawalStatus.Sequenced
         }
 
-        waitForFinalizedWithdrawal(pendingUsdcWithdrawal.id)
+        waitForFinalizedWithdrawal(pendingUsdcWithdrawal.id, WithdrawalStatus.Complete)
 
         waitForBalance(
             apiClient,
@@ -443,7 +443,7 @@ class WithdrawalTest {
         var usdcWithdrawal2 = apiClient.getWithdrawal(pendingUsdcWithdrawal2.id).withdrawal
         assertEquals(AssetAmount(usdc, "800").inFundamentalUnits, usdcWithdrawal2.amount)
 
-        waitForFinalizedWithdrawal(pendingUsdcWithdrawal2.id)
+        waitForFinalizedWithdrawal(pendingUsdcWithdrawal2.id, WithdrawalStatus.Complete)
 
         usdcWithdrawal2 = apiClient.getWithdrawal(pendingUsdcWithdrawal2.id).withdrawal
         assertEquals(WithdrawalStatus.Complete, usdcWithdrawal2.status)
@@ -546,7 +546,7 @@ class WithdrawalTest {
             ),
         )
 
-        waitForFinalizedWithdrawal(pendingBtcWithdrawal.id)
+        waitForFinalizedWithdrawal(pendingBtcWithdrawal.id, WithdrawalStatus.Complete)
 
         val btcWithdrawal = apiClient.getWithdrawal(pendingBtcWithdrawal.id).withdrawal
         assertEquals(WithdrawalStatus.Complete, btcWithdrawal.status)
@@ -575,7 +575,7 @@ class WithdrawalTest {
             )
         }
 
-        waitForFinalizedWithdrawal(pendingBtcWithdrawal.id)
+        waitForFinalizedWithdrawal(pendingBtcWithdrawal.id, WithdrawalStatus.Failed)
 
         val btcWithdrawal2 = apiClient.getWithdrawal(pendingBtcWithdrawal.id).withdrawal
         assertEquals(WithdrawalStatus.Failed, btcWithdrawal2.status)

--- a/integrationtests/src/test/kotlin/xyz/funkybit/integrationtests/exchange/LinkedSignerTest.kt
+++ b/integrationtests/src/test/kotlin/xyz/funkybit/integrationtests/exchange/LinkedSignerTest.kt
@@ -108,7 +108,7 @@ class LinkedSignerTest : OrderBaseTest() {
             ),
         )
 
-        waitForFinalizedWithdrawal(pendingBtcWithdrawal.id)
+        waitForFinalizedWithdrawal(pendingBtcWithdrawal.id, WithdrawalStatus.Complete)
 
         val btcWithdrawal = apiClient.getWithdrawal(pendingBtcWithdrawal.id).withdrawal
         assertEquals(WithdrawalStatus.Complete, btcWithdrawal.status)

--- a/integrationtests/src/test/kotlin/xyz/funkybit/integrationtests/repeater/GasMonitorTest.kt
+++ b/integrationtests/src/test/kotlin/xyz/funkybit/integrationtests/repeater/GasMonitorTest.kt
@@ -8,16 +8,16 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import xyz.funkybit.core.db.notifyDbListener
 import xyz.funkybit.integrationtests.testutils.AppUnderTestRunner
+import xyz.funkybit.integrationtests.testutils.isTestEnvRun
 import xyz.funkybit.integrationtests.utils.clearLogMessages
 import xyz.funkybit.integrationtests.utils.logMessages
-import java.lang.System.getenv
 import java.util.concurrent.TimeUnit
 
 @ExtendWith(AppUnderTestRunner::class)
 class GasMonitorTest {
     @Test
     fun `test gas monitor`() {
-        Assumptions.assumeTrue((getenv("INTEGRATION_RUN") ?: "0") != "1")
+        Assumptions.assumeFalse(isTestEnvRun())
         clearLogMessages()
         transaction {
             notifyDbListener("repeater_app_task_ctl", "gas_monitor:10000000000000")

--- a/integrationtests/src/test/kotlin/xyz/funkybit/integrationtests/settlement/SettlementTest.kt
+++ b/integrationtests/src/test/kotlin/xyz/funkybit/integrationtests/settlement/SettlementTest.kt
@@ -22,6 +22,7 @@ import xyz.funkybit.core.utils.generateOrderNonce
 import xyz.funkybit.core.utils.toFundamentalUnits
 import xyz.funkybit.integrationtests.testutils.AppUnderTestRunner
 import xyz.funkybit.integrationtests.testutils.OrderBaseTest
+import xyz.funkybit.integrationtests.testutils.isTestEnvRun
 import xyz.funkybit.integrationtests.testutils.waitForFinalizedWithdrawal
 import xyz.funkybit.integrationtests.utils.AssetAmount
 import xyz.funkybit.integrationtests.utils.ExpectedBalance
@@ -210,7 +211,7 @@ class SettlementTest : OrderBaseTest() {
             assertLimitsMessageReceived(market, base = takerStartingBaseBalance - baseWithdrawalAmount, quote = takerStartingQuoteBalance)
         }
 
-        waitForFinalizedWithdrawal(pendingBaseWithdrawal.id)
+        waitForFinalizedWithdrawal(pendingBaseWithdrawal.id, WithdrawalStatus.Complete)
 
         takerWsClient.apply {
             assertBalancesMessageReceived(
@@ -227,7 +228,7 @@ class SettlementTest : OrderBaseTest() {
             WithdrawalEntity[pendingBaseWithdrawal.id].status = WithdrawalStatus.Sequenced
         }
 
-        waitForFinalizedWithdrawal(pendingBaseWithdrawal.id)
+        waitForFinalizedWithdrawal(pendingBaseWithdrawal.id, WithdrawalStatus.Complete)
 
         takerWsClient.apply {
             assertBalancesMessageReceived(
@@ -455,7 +456,7 @@ class SettlementTest : OrderBaseTest() {
             assertLimitsMessageReceived(market, base = makerStartingBaseBalance - baseWithdrawalAmount, quote = makerStartingQuoteBalance)
         }
 
-        waitForFinalizedWithdrawal(pendingBaseWithdrawal.id)
+        waitForFinalizedWithdrawal(pendingBaseWithdrawal.id, WithdrawalStatus.Complete)
 
         makerWsClient.apply {
             assertBalancesMessageReceived()
@@ -467,7 +468,7 @@ class SettlementTest : OrderBaseTest() {
             WithdrawalEntity[pendingBaseWithdrawal.id].status = WithdrawalStatus.Sequenced
         }
 
-        waitForFinalizedWithdrawal(pendingBaseWithdrawal.id)
+        waitForFinalizedWithdrawal(pendingBaseWithdrawal.id, WithdrawalStatus.Complete)
 
         makerWsClient.apply {
             assertBalancesMessageReceived()
@@ -721,7 +722,7 @@ class SettlementTest : OrderBaseTest() {
             assertLimitsMessageReceived(market, base = takerStartingBaseBalance - baseWithdrawalAmount, quote = takerStartingQuoteBalance)
         }
 
-        waitForFinalizedWithdrawal(pendingBaseWithdrawal.id)
+        waitForFinalizedWithdrawal(pendingBaseWithdrawal.id, WithdrawalStatus.Complete)
 
         takerWsClient.apply {
             assertBalancesMessageReceived(
@@ -738,7 +739,7 @@ class SettlementTest : OrderBaseTest() {
             WithdrawalEntity[pendingBaseWithdrawal.id].status = WithdrawalStatus.Sequenced
         }
 
-        waitForFinalizedWithdrawal(pendingBaseWithdrawal.id)
+        waitForFinalizedWithdrawal(pendingBaseWithdrawal.id, WithdrawalStatus.Complete)
 
         takerWsClient.apply {
             assertBalancesMessageReceived(
@@ -943,7 +944,7 @@ class SettlementTest : OrderBaseTest() {
             assertLimitsMessageReceived(market, base = makerStartingBaseBalance - baseWithdrawalAmount, quote = makerStartingQuoteBalance)
         }
 
-        waitForFinalizedWithdrawal(pendingBaseWithdrawal.id)
+        waitForFinalizedWithdrawal(pendingBaseWithdrawal.id, WithdrawalStatus.Complete)
 
         makerWsClient.apply {
             assertBalancesMessageReceived()
@@ -955,7 +956,7 @@ class SettlementTest : OrderBaseTest() {
             WithdrawalEntity[pendingBaseWithdrawal.id].status = WithdrawalStatus.Sequenced
         }
 
-        waitForFinalizedWithdrawal(pendingBaseWithdrawal.id)
+        waitForFinalizedWithdrawal(pendingBaseWithdrawal.id, WithdrawalStatus.Complete)
 
         makerWsClient.apply {
             assertBalancesMessageReceived()
@@ -1157,7 +1158,7 @@ class SettlementTest : OrderBaseTest() {
 
     @Test
     fun `settlement failure - manually rollback trade`() {
-        Assumptions.assumeTrue((System.getenv("INTEGRATION_RUN") ?: "0") != "1")
+        Assumptions.assumeFalse(isTestEnvRun())
         val market = btcEthMarket
         val baseSymbol = btc
         val quoteSymbol = eth
@@ -1499,7 +1500,7 @@ class SettlementTest : OrderBaseTest() {
         }
 
         // wait for the withdrawal to finalize and verify it completed and taker quote assets are zero
-        waitForFinalizedWithdrawal(pendingWithdrawal.id)
+        waitForFinalizedWithdrawal(pendingWithdrawal.id, WithdrawalStatus.Complete)
         assertEquals(WithdrawalStatus.Complete, takerApiClient.getWithdrawal(pendingWithdrawal.id).withdrawal.status)
 
         takerWsClient.apply {

--- a/integrationtests/src/test/kotlin/xyz/funkybit/integrationtests/testutils/BalanceHelper.kt
+++ b/integrationtests/src/test/kotlin/xyz/funkybit/integrationtests/testutils/BalanceHelper.kt
@@ -7,6 +7,7 @@ import xyz.funkybit.core.model.db.BlockchainTransactionStatus
 import xyz.funkybit.core.model.db.TxHash
 import xyz.funkybit.core.model.db.WithdrawalEntity
 import xyz.funkybit.core.model.db.WithdrawalId
+import xyz.funkybit.core.model.db.WithdrawalStatus
 import xyz.funkybit.integrationtests.utils.ExpectedBalance
 import xyz.funkybit.integrationtests.utils.Faucet
 import xyz.funkybit.integrationtests.utils.TestApiClient
@@ -43,11 +44,11 @@ fun waitForFinalizedWithdrawalWithForking(id: WithdrawalId) {
         }
 }
 
-fun waitForFinalizedWithdrawal(id: WithdrawalId) {
+fun waitForFinalizedWithdrawal(id: WithdrawalId, expectedStatus: WithdrawalStatus) {
     waitFor {
         Faucet.mine()
         transaction {
-            WithdrawalEntity[id].status.isFinal()
+            WithdrawalEntity[id].status == expectedStatus
         }
     }
 }

--- a/scripts/envs/test.yml
+++ b/scripts/envs/test.yml
@@ -11,6 +11,7 @@ environment:
     ENABLE_TEST_ROUTES: "true"
     FAUCET_MODE: AllSymbols
     BITCOIN_NETWORK_ENABLED: "false"
+    REPEATER_AUTOMATIC_TASK_SCHEDULING: "false"
   sequencer:
     QUEUE_HOME: "/data/queues/test"
     CHECKPOINTS_ENABLED: "false"


### PR DESCRIPTION
- disabled repeater tasks automatic scheduling in tests so that they are run only when explicitly triggered from the test
- we now store gas alert status in DB and clear it between tests instead of just keeping it in memory since because app is not restarted in between individual tests, gas monitor alert could be triggered before it actually gets to the gas monitor test that expects no alerts in the beginning
- increased expected deposit confirmations from 1 to 2 to avoid race condition in `test on chain deposit detection - forks are handled`
- set Anvil mining interval to 60 minutes in test to make sure no mining is happening without explicit instruction to do so from the test (we had automining disabled previously, but that's not enough since that setting disables mining for each transaction, but does not disable interval mining)
- Changed `waitForFinalizedWithdrawal` test helper to explicitly expect certain withdrawal status instead of either `complete` or `failed` as this might lead to more determinism