### PR TITLE
Fix flaky order execution test

### DIFF
--- a/backend/src/main/kotlin/xyz/funkybit/apps/api/model/websocket/OutgoingWSMessage.kt
+++ b/backend/src/main/kotlin/xyz/funkybit/apps/api/model/websocket/OutgoingWSMessage.kt
@@ -125,16 +125,16 @@ data class Prices(
     val duration: OHLCDuration,
     val ohlc: List<OHLC>,
     val full: Boolean,
-    val dailyChange: Double,
+    val dailyChange: BigDecimalJson,
 ) : Publishable()
 
 @Serializable
 data class OHLC(
     val start: Instant,
-    val open: Double,
-    val high: Double,
-    val low: Double,
-    val close: Double,
+    val open: BigDecimalJson,
+    val high: BigDecimalJson,
+    val low: BigDecimalJson,
+    val close: BigDecimalJson,
     val duration: OHLCDuration,
 )
 

--- a/backend/src/main/kotlin/xyz/funkybit/core/model/db/BroadcasterJob.kt
+++ b/backend/src/main/kotlin/xyz/funkybit/core/model/db/BroadcasterJob.kt
@@ -16,6 +16,7 @@ import xyz.funkybit.apps.api.model.websocket.Prices
 import xyz.funkybit.apps.api.model.websocket.Publishable
 import xyz.funkybit.core.db.notifyDbListener
 import xyz.funkybit.core.model.Address
+import java.math.BigDecimal
 
 private val logger = KotlinLogging.logger {}
 
@@ -25,8 +26,8 @@ data class BroadcasterNotification(
     val recipient: Address?,
 ) {
     companion object {
-        fun pricesForMarketPeriods(marketId: MarketId, duration: OHLCDuration, ohlc: List<OHLCEntity>, full: Boolean, dailyChange: Double): BroadcasterNotification =
-            BroadcasterNotification(Prices(marketId, duration, ohlc.map { it.toWSResponse() }, full, dailyChange), null)
+        fun pricesForMarketPeriods(marketId: MarketId, duration: OHLCDuration, ohlc: List<OHLCEntity>, full: Boolean, dailyChange: BigDecimal): BroadcasterNotification =
+            BroadcasterNotification(Prices(marketId, duration, ohlc.map { it.toWSResponse() }, full, dailyChange.stripTrailingZeros()), null)
 
         fun limits(wallet: WalletEntity): BroadcasterNotification =
             BroadcasterNotification(Limits(LimitEntity.forWallet(wallet)), recipient = wallet.address)

--- a/backend/src/main/kotlin/xyz/funkybit/core/model/db/OHLC.kt
+++ b/backend/src/main/kotlin/xyz/funkybit/core/model/db/OHLC.kt
@@ -113,10 +113,10 @@ class OHLCEntity(guid: EntityID<OHLCId>) : GUIDEntity<OHLCId>(guid) {
     fun toWSResponse(): OHLC {
         return OHLC(
             start = this.start,
-            open = this.open.toDouble(),
-            high = this.high.toDouble(),
-            low = this.low.toDouble(),
-            close = this.close.toDouble(),
+            open = this.open.stripTrailingZeros(),
+            high = this.high.stripTrailingZeros(),
+            low = this.low.stripTrailingZeros(),
+            close = this.close.stripTrailingZeros(),
             duration = this.duration,
         )
     }

--- a/backend/src/test/kotlin/xyz/funkybit/core/ohlc/OHLCDurationTest.kt
+++ b/backend/src/test/kotlin/xyz/funkybit/core/ohlc/OHLCDurationTest.kt
@@ -77,10 +77,10 @@ class OHLCDurationTest : TestWithDb() {
                 expected = OHLCDuration.entries.map {
                     OHLC(
                         start = it.durationStart(now),
-                        open = tradePrice.toDouble(),
-                        high = tradePrice.toDouble(),
-                        low = tradePrice.toDouble(),
-                        close = tradePrice.toDouble(),
+                        open = tradePrice,
+                        high = tradePrice,
+                        low = tradePrice,
+                        close = tradePrice,
                         duration = it,
                     )
                 }.toSet(),
@@ -99,10 +99,10 @@ class OHLCDurationTest : TestWithDb() {
                 expected = OHLCDuration.entries.map {
                     OHLC(
                         start = it.durationStart(now),
-                        open = tradePrice.toDouble(),
-                        high = higherTradePrice.toDouble(),
-                        low = tradePrice.toDouble(),
-                        close = higherTradePrice.toDouble(),
+                        open = tradePrice,
+                        high = higherTradePrice,
+                        low = tradePrice,
+                        close = higherTradePrice,
                         duration = it,
                     )
                 }.toSet(),
@@ -124,10 +124,10 @@ class OHLCDurationTest : TestWithDb() {
                 expected = OHLCDuration.entries.map {
                     OHLC(
                         start = it.durationStart(now),
-                        open = tradePrice.toDouble(),
-                        high = higherTradePrice.toDouble(),
-                        low = lowerTradePrice.toDouble(),
-                        close = lowerTradePrice.toDouble(),
+                        open = tradePrice,
+                        high = higherTradePrice,
+                        low = lowerTradePrice,
+                        close = lowerTradePrice,
                         duration = it,
                     )
                 }.toSet(),
@@ -150,18 +150,18 @@ class OHLCDurationTest : TestWithDb() {
                         OHLCDuration.P1M -> setOf(
                             OHLC(
                                 start = it.durationStart(now),
-                                open = tradePrice.toDouble(),
-                                high = higherTradePrice.toDouble(),
-                                low = lowerTradePrice.toDouble(),
-                                close = lowerTradePrice.toDouble(),
+                                open = tradePrice,
+                                high = higherTradePrice,
+                                low = lowerTradePrice,
+                                close = lowerTradePrice,
                                 duration = it,
                             ),
                             OHLC(
                                 start = it.durationStart(nextMinute),
-                                open = lowerTradePrice.toDouble(),
-                                high = lowerTradePrice.toDouble(),
-                                low = lowerTradePrice.toDouble(),
-                                close = lowerTradePrice.toDouble(),
+                                open = lowerTradePrice,
+                                high = lowerTradePrice,
+                                low = lowerTradePrice,
+                                close = lowerTradePrice,
                                 duration = it,
                             ),
                         )
@@ -169,10 +169,10 @@ class OHLCDurationTest : TestWithDb() {
                         else -> setOf(
                             OHLC(
                                 start = it.durationStart(now),
-                                open = tradePrice.toDouble(),
-                                high = higherTradePrice.toDouble(),
-                                low = lowerTradePrice.toDouble(),
-                                close = lowerTradePrice.toDouble(),
+                                open = tradePrice,
+                                high = higherTradePrice,
+                                low = lowerTradePrice,
+                                close = lowerTradePrice,
                                 duration = it,
                             ),
                         )
@@ -194,26 +194,26 @@ class OHLCDurationTest : TestWithDb() {
                         OHLCDuration.P1M -> setOf(
                             OHLC(
                                 start = it.durationStart(now),
-                                open = tradePrice.toDouble(),
-                                high = higherTradePrice.toDouble(),
-                                low = lowerTradePrice.toDouble(),
-                                close = lowerTradePrice.toDouble(),
+                                open = tradePrice,
+                                high = higherTradePrice,
+                                low = lowerTradePrice,
+                                close = lowerTradePrice,
                                 duration = it,
                             ),
                             OHLC(
                                 start = it.durationStart(nextMinute),
-                                open = lowerTradePrice.toDouble(),
-                                high = lowerTradePrice.toDouble(),
-                                low = lowerTradePrice.toDouble(),
-                                close = lowerTradePrice.toDouble(),
+                                open = lowerTradePrice,
+                                high = lowerTradePrice,
+                                low = lowerTradePrice,
+                                close = lowerTradePrice,
                                 duration = it,
                             ),
                             OHLC(
                                 start = it.durationStart(nextFiveMinutes),
-                                open = higherTradePrice.toDouble(),
-                                high = higherTradePrice.toDouble(),
-                                low = higherTradePrice.toDouble(),
-                                close = higherTradePrice.toDouble(),
+                                open = higherTradePrice,
+                                high = higherTradePrice,
+                                low = higherTradePrice,
+                                close = higherTradePrice,
                                 duration = it,
                             ),
                         )
@@ -221,18 +221,18 @@ class OHLCDurationTest : TestWithDb() {
                         OHLCDuration.P5M -> setOf(
                             OHLC(
                                 start = it.durationStart(nextMinute),
-                                open = tradePrice.toDouble(),
-                                high = higherTradePrice.toDouble(),
-                                low = lowerTradePrice.toDouble(),
-                                close = lowerTradePrice.toDouble(),
+                                open = tradePrice,
+                                high = higherTradePrice,
+                                low = lowerTradePrice,
+                                close = lowerTradePrice,
                                 duration = it,
                             ),
                             OHLC(
                                 start = it.durationStart(nextFiveMinutes),
-                                open = higherTradePrice.toDouble(),
-                                high = higherTradePrice.toDouble(),
-                                low = higherTradePrice.toDouble(),
-                                close = higherTradePrice.toDouble(),
+                                open = higherTradePrice,
+                                high = higherTradePrice,
+                                low = higherTradePrice,
+                                close = higherTradePrice,
                                 duration = it,
                             ),
                         )
@@ -240,10 +240,10 @@ class OHLCDurationTest : TestWithDb() {
                         else -> setOf(
                             OHLC(
                                 start = it.durationStart(now),
-                                open = tradePrice.toDouble(),
-                                high = higherTradePrice.toDouble(),
-                                low = lowerTradePrice.toDouble(),
-                                close = higherTradePrice.toDouble(),
+                                open = tradePrice,
+                                high = higherTradePrice,
+                                low = lowerTradePrice,
+                                close = higherTradePrice,
                                 duration = it,
                             ),
                         )

--- a/integrationtests/src/test/kotlin/xyz/funkybit/integrationtests/api/OrderExecutionTest.kt
+++ b/integrationtests/src/test/kotlin/xyz/funkybit/integrationtests/api/OrderExecutionTest.kt
@@ -57,6 +57,7 @@ import xyz.funkybit.integrationtests.utils.verifyApiReturnsSameLimits
 import java.math.BigDecimal
 import java.math.BigInteger
 import kotlin.test.Test
+import kotlin.test.assertContains
 import kotlin.test.assertIs
 
 @ExtendWith(AppUnderTestRunner::class)
@@ -296,10 +297,10 @@ class OrderExecutionTest : OrderBaseTest() {
                 assertEquals(
                     OHLC(
                         start = OHLCDuration.P5M.durationStart(trade.timestamp),
-                        open = 17.55,
-                        high = 17.55,
-                        low = 17.55,
-                        close = 17.55,
+                        open = BigDecimal("17.55"),
+                        high = BigDecimal("17.55"),
+                        low = BigDecimal("17.55"),
+                        close = BigDecimal("17.55"),
                         duration = OHLCDuration.P5M,
                     ),
                     msg.ohlc.last(),
@@ -314,10 +315,10 @@ class OrderExecutionTest : OrderBaseTest() {
                 assertEquals(
                     OHLC(
                         start = OHLCDuration.P5M.durationStart(trade.timestamp),
-                        open = 17.55,
-                        high = 17.55,
-                        low = 17.55,
-                        close = 17.55,
+                        open = BigDecimal("17.55"),
+                        high = BigDecimal("17.55"),
+                        low = BigDecimal("17.55"),
+                        close = BigDecimal("17.55"),
                         duration = OHLCDuration.P5M,
                     ),
                     msg.ohlc.last(),
@@ -502,17 +503,14 @@ class OrderExecutionTest : OrderBaseTest() {
 
         takerWsClient.apply {
             assertPricesMessageReceived(market.id) { msg ->
-                assertEquals(
-                    OHLC(
-                        start = OHLCDuration.P5M.durationStart(trade2.timestamp),
-                        open = 17.55,
-                        high = 17.55,
-                        low = 17.5,
-                        close = 17.5,
-                        duration = OHLCDuration.P5M,
-                    ),
-                    msg.ohlc.last(),
-                )
+                val lastOhlc = msg.ohlc.last()
+                assertEquals(OHLCDuration.P5M.durationStart(trade2.timestamp), lastOhlc.start)
+                // open and high props are asserted like this since sometimes trade1 and trade2 don't get into the same 5min bucket
+                assertContains(listOf(BigDecimal("17.5"), BigDecimal("17.55")), lastOhlc.open)
+                assertContains(listOf(BigDecimal("17.5"), BigDecimal("17.55")), lastOhlc.high)
+                assertEquals(BigDecimal("17.5"), lastOhlc.low)
+                assertEquals(BigDecimal("17.5"), lastOhlc.close)
+                assertEquals(OHLCDuration.P5M, lastOhlc.duration)
             }
 
             assertLimitsMessageReceived(market, base = BigDecimal("0.00030865"), quote = BigDecimal("1.9943821454"))
@@ -533,17 +531,14 @@ class OrderExecutionTest : OrderBaseTest() {
 
         makerWsClient.apply {
             assertPricesMessageReceived(market.id) { msg ->
-                assertEquals(
-                    OHLC(
-                        start = OHLCDuration.P5M.durationStart(trade2.timestamp),
-                        open = 17.55,
-                        high = 17.55,
-                        low = 17.5,
-                        close = 17.5,
-                        duration = OHLCDuration.P5M,
-                    ),
-                    msg.ohlc.last(),
-                )
+                val lastOhlc = msg.ohlc.last()
+                assertEquals(OHLCDuration.P5M.durationStart(trade2.timestamp), lastOhlc.start)
+                // open and high props are asserted like this since sometimes trade1 and trade2 don't get into the same 5min bucket
+                assertContains(listOf(BigDecimal("17.5"), BigDecimal("17.55")), lastOhlc.open)
+                assertContains(listOf(BigDecimal("17.5"), BigDecimal("17.55")), lastOhlc.high)
+                assertEquals(BigDecimal("17.5"), lastOhlc.low)
+                assertEquals(BigDecimal("17.5"), lastOhlc.close)
+                assertEquals(OHLCDuration.P5M, lastOhlc.duration)
             }
 
             assertLimitsMessageReceived(market, base = BigDecimal("0.19958024"), quote = BigDecimal("2.0053255427"))
@@ -800,10 +795,10 @@ class OrderExecutionTest : OrderBaseTest() {
                         // initial ohlc in the BTC/USDC market
                         // price is a weighted price across all order execution of market order
                         start = OHLCDuration.P5M.durationStart(Clock.System.now()),
-                        open = 68400.0,
-                        high = 68400.0,
-                        low = 68400.0,
-                        close = 68400.0,
+                        open = BigDecimal("68400"),
+                        high = BigDecimal("68400"),
+                        low = BigDecimal("68400"),
+                        close = BigDecimal("68400"),
                         duration = OHLCDuration.P5M,
                     ),
                     msg.ohlc.last(),
@@ -823,10 +818,10 @@ class OrderExecutionTest : OrderBaseTest() {
                 assertEquals(
                     OHLC(
                         start = OHLCDuration.P5M.durationStart(Clock.System.now()),
-                        open = 68400.0,
-                        high = 68400.0,
-                        low = 68400.0,
-                        close = 68400.0,
+                        open = BigDecimal("68400"),
+                        high = BigDecimal("68400"),
+                        low = BigDecimal("68400"),
+                        close = BigDecimal("68400"),
                         duration = OHLCDuration.P5M,
                     ),
                     msg.ohlc.last(),

--- a/integrationtests/src/test/kotlin/xyz/funkybit/integrationtests/settlement/SettlementTest.kt
+++ b/integrationtests/src/test/kotlin/xyz/funkybit/integrationtests/settlement/SettlementTest.kt
@@ -144,10 +144,10 @@ class SettlementTest : OrderBaseTest() {
                         assertEquals(OrderStatus.Filled, msg.order.status)
                     }
                 }
-                assertBalancesMessageReceived {}
-                assertOrderBookMessageReceived(market.id) {}
+                assertBalancesMessageReceived()
+                assertOrderBookMessageReceived(market.id)
                 repeat(2) {
-                    assertPricesMessageReceived(market.id) {}
+                    assertPricesMessageReceived(market.id)
                 }
                 assertLimitsMessageReceived()
             }

--- a/mocker/src/main/kotlin/xyz/funkybit/mocker/core/Maker.kt
+++ b/mocker/src/main/kotlin/xyz/funkybit/mocker/core/Maker.kt
@@ -177,7 +177,7 @@ class Maker(
                     logger.info { "$id: full price update for ${message.market}" }
                     if (!quotesCreated) {
                         markets.find { it.id == message.market }?.let {
-                            createQuotes(message.market, levels, levelsSpread, message.ohlc.lastOrNull()?.close?.toBigDecimal() ?: BigDecimal.ONE)
+                            createQuotes(message.market, levels, levelsSpread, message.ohlc.lastOrNull()?.close ?: BigDecimal.ONE)
                             quotesCreated = true
                         }
                     }
@@ -185,7 +185,7 @@ class Maker(
                     if (message.ohlc.isNotEmpty()) {
                         logger.info { "$id: incremental price update $message" }
                         markets.find { it.id == message.market }?.let {
-                            adjustQuotes(it, message.ohlc.last().close.toBigDecimal())
+                            adjustQuotes(it, message.ohlc.last().close)
                         }
                     }
                 }

--- a/mocker/src/main/kotlin/xyz/funkybit/mocker/core/Taker.kt
+++ b/mocker/src/main/kotlin/xyz/funkybit/mocker/core/Taker.kt
@@ -185,7 +185,7 @@ class Taker(
                     logger.info { "$id: incremental price update: $message" }
                 }
                 message.ohlc.lastOrNull()?.let {
-                    marketPrices[message.market] = it.close.toBigDecimal()
+                    marketPrices[message.market] = it.close
                 }
             }
 

--- a/sequencer/src/main/kotlin/xyz/funkybit/sequencer/apps/services/SequencerResponseProcessorService.kt
+++ b/sequencer/src/main/kotlin/xyz/funkybit/sequencer/apps/services/SequencerResponseProcessorService.kt
@@ -452,7 +452,7 @@ object SequencerResponseProcessorService {
                             duration = it.duration,
                             ohlc = listOf(it),
                             full = false,
-                            dailyChange = h24ClosePrice?.let { (weightedPrice.toDouble() - it.toDouble()) / it.toDouble() } ?: 0.0,
+                            dailyChange = h24ClosePrice?.let { closePrice -> (weightedPrice - closePrice) / closePrice } ?: BigDecimal.ZERO,
                         )
                     }
             }.flatten()

--- a/web-ui/src/websocketMessages.ts
+++ b/web-ui/src/websocketMessages.ts
@@ -67,10 +67,10 @@ export type OHLCDuration = z.infer<typeof OHLCDurationSchema>
 const OHLCSchema = z.object({
   start: z.coerce.date(),
   duration: OHLCDurationSchema,
-  open: z.number(),
-  high: z.number(),
-  low: z.number(),
-  close: z.number()
+  open: z.coerce.number(),
+  high: z.coerce.number(),
+  low: z.coerce.number(),
+  close: z.coerce.number()
 })
 export type OHLC = z.infer<typeof OHLCSchema>
 
@@ -78,7 +78,7 @@ export const PricesSchema = z.object({
   type: z.literal('Prices'),
   full: z.boolean(),
   ohlc: z.array(OHLCSchema),
-  dailyChange: z.number()
+  dailyChange: z.coerce.number()
 })
 export type Prices = z.infer<typeof PricesSchema>
 


### PR DESCRIPTION
Was sometimes failing with this:

```
org.opentest4j.AssertionFailedError: expected: <OHLC(start=2024-08-15T15:30:00Z, open=17.55, high=17.55, low=17.5, close=17.5, duration=P5M)> but was: <OHLC(start=2024-08-15T15:30:00Z, open=17.5, high=17.5, low=17.5, close=17.5, duration=P5M)>
	at app//org.junit.jupiter.api.AssertionFailureBuilder.build(AssertionFailureBuilder.java:151)
	at app//org.junit.jupiter.api.AssertionFailureBuilder.buildAndThrow(AssertionFailureBuilder.java:132)
	at app//org.junit.jupiter.api.AssertEquals.failNotEqual(AssertEquals.java:197)
	at app//org.junit.jupiter.api.AssertEquals.assertEquals(AssertEquals.java:182)
	at app//org.junit.jupiter.api.AssertEquals.assertEquals(AssertEquals.java:177)
	at app//org.junit.jupiter.api.Assertions.assertEquals(Assertions.java:1145)
	at app//xyz.funkybit.integrationtests.api.OrderExecutionTest$order execution$15$1.invoke(OrderExecutionTest.kt:505)
	at app//xyz.funkybit.integrationtests.api.OrderExecutionTest$order execution$15$1.invoke(OrderExecutionTest.kt:504)
```