### PR TITLE
Fix OrderBookDiffBroadcastingTest

### DIFF
--- a/integrationtests/src/test/kotlin/xyz/funkybit/integrationtests/testutils/AppUnderTestRunner.kt
+++ b/integrationtests/src/test/kotlin/xyz/funkybit/integrationtests/testutils/AppUnderTestRunner.kt
@@ -17,6 +17,7 @@ import xyz.funkybit.core.blockchain.ChainManager
 import xyz.funkybit.core.blockchain.ContractType
 import xyz.funkybit.core.blockchain.bitcoin.BitcoinClient
 import xyz.funkybit.core.db.DbConfig
+import xyz.funkybit.core.db.notifyDbListener
 import xyz.funkybit.core.model.MarketMinFee
 import xyz.funkybit.core.model.Symbol
 import xyz.funkybit.core.model.WithdrawalFee
@@ -264,6 +265,8 @@ class AppUnderTestRunner : BeforeAllCallback, BeforeEachCallback {
             WalletTable.deleteAll()
             OHLCTable.deleteAll()
             FaucetDripTable.deleteAll()
+
+            notifyDbListener("broadcaster_ctl", "clear-cache")
         }
     }
 }


### PR DESCRIPTION
Was failing sometimes due to caches in Broadcaster containing data from previous test runs:

```
Expected :OrderBook(marketId=BTC:1337/USDC:1337, buy=[], sell=[], last=LastTrade(price=0.0, direction=Unchanged))
Actual   :OrderBook(marketId=BTC:1337/USDC:1337, buy=[Entry(price=68200.0, size=0.009), Entry(price=68100.0, size=0.006)], sell=[], last=LastTrade(price=68400.0, direction=Up))
```