### PR TITLE
Remove Otterscan from test env

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -61,7 +61,7 @@ jobs:
     uses: ./.github/workflows/start-services.yml
     with:
       environment: test
-      services: "anvil,anvil2,ring,api,garp,sequencer,telegrambot,otterscan,otterscan2"
+      services: "anvil,anvil2,ring,api,garp,sequencer,telegrambot"
 
   deploy_web_ui:
     name: Deploy Web UI
@@ -106,5 +106,5 @@ jobs:
     uses: ./.github/workflows/stop-services.yml
     with:
       environment: test
-      services: "api,ring,telegrambot,garp,sequencer,anvil,otterscan,anvil2,otterscan2"
+      services: "api,ring,telegrambot,garp,sequencer,anvil,anvil2"
 

--- a/terraform/test/main.tf
+++ b/terraform/test/main.tf
@@ -111,31 +111,6 @@ module "anvil" {
   deployment_maximum_percent              = 100
 }
 
-module "otterscan" {
-  source            = "../modules/ecs_task"
-  name_prefix       = local.name_prefix
-  task_name         = "otterscan"
-  image             = "otterscan"
-  ecs_cluster_id    = module.ecs.cluster.id
-  app_ecs_task_role = module.ecs.app_ecs_task_role
-  aws_region        = var.aws_region
-  subnet_id_1       = module.vpc.private_subnet_id_1
-  subnet_id_2       = module.vpc.private_subnet_id_2
-  vpc               = module.vpc.vpc
-  allow_inbound     = true
-  hostnames = [
-    "${local.name_prefix}-otterscan.${data.terraform_remote_state.shared.outputs.zone.name}"
-  ]
-  lb_https_listener_arn                   = module.alb.https_listener_arn
-  lb_priority                             = 102
-  lb_dns_name                             = module.alb.dns_name
-  zone                                    = data.terraform_remote_state.shared.outputs.zone
-  tcp_ports                               = [80]
-  health_check                            = "/"
-  health_check_status                     = "200"
-  service_discovery_private_dns_namespace = module.vpc.service_discovery_private_dns_namespace
-}
-
 module "anvil2" {
   source            = "../modules/ecs_task"
   name_prefix       = local.name_prefix
@@ -163,31 +138,6 @@ module "anvil2" {
   service_discovery_private_dns_namespace = module.vpc.service_discovery_private_dns_namespace
   deployment_minimum_healthy_percent      = 0
   deployment_maximum_percent              = 100
-}
-
-module "otterscan2" {
-  source            = "../modules/ecs_task"
-  name_prefix       = local.name_prefix
-  task_name         = "otterscan2"
-  image             = "otterscan"
-  ecs_cluster_id    = module.ecs.cluster.id
-  app_ecs_task_role = module.ecs.app_ecs_task_role
-  aws_region        = var.aws_region
-  subnet_id_1       = module.vpc.private_subnet_id_1
-  subnet_id_2       = module.vpc.private_subnet_id_2
-  vpc               = module.vpc.vpc
-  allow_inbound     = true
-  hostnames = [
-    "${local.name_prefix}-otterscan2.${data.terraform_remote_state.shared.outputs.zone.name}"
-  ]
-  lb_https_listener_arn                   = module.alb.https_listener_arn
-  lb_priority                             = 104
-  lb_dns_name                             = module.alb.dns_name
-  zone                                    = data.terraform_remote_state.shared.outputs.zone
-  tcp_ports                               = [80]
-  health_check                            = "/"
-  health_check_status                     = "200"
-  service_discovery_private_dns_namespace = module.vpc.service_discovery_private_dns_namespace
 }
 
 module "bastion" {


### PR DESCRIPTION
No point in having Otterscan in test env now that we stop all services at the end of CI pipeline