### PR TITLE
Fix TMA referral points test flakiness

### DIFF
--- a/backend/src/main/kotlin/xyz/funkybit/core/repeater/tasks/GasMonitorTask.kt
+++ b/backend/src/main/kotlin/xyz/funkybit/core/repeater/tasks/GasMonitorTask.kt
@@ -11,6 +11,8 @@ import kotlin.time.Duration.Companion.seconds
 class GasMonitorTask : RepeaterBaseTask(
     invokePeriod = 30.seconds,
 ) {
+    override val name: String = "gas_monitor"
+
     val logger = KotlinLogging.logger {}
 
     private var minimumGasUnitsOverride: BigInteger? = null

--- a/backend/src/main/kotlin/xyz/funkybit/core/repeater/tasks/ReferralPointsTask.kt
+++ b/backend/src/main/kotlin/xyz/funkybit/core/repeater/tasks/ReferralPointsTask.kt
@@ -22,6 +22,8 @@ class ReferralPointsTask(val config: DailyPointBonusTaskConfig = DailyPointBonus
     invokePeriod = 1.minutes,
     maxPlannedExecutionTime = 10.seconds,
 ) {
+    override val name: String = "referral_points"
+
     private val logger = KotlinLogging.logger {}
 
     override fun runWithLock() {

--- a/integrationtests/src/test/kotlin/xyz/funkybit/integrationtests/api/TelegramMiniAppApiTest.kt
+++ b/integrationtests/src/test/kotlin/xyz/funkybit/integrationtests/api/TelegramMiniAppApiTest.kt
@@ -16,7 +16,6 @@ import xyz.funkybit.apps.api.model.ReasonCode
 import xyz.funkybit.apps.api.model.tma.ClaimRewardApiRequest
 import xyz.funkybit.apps.api.model.tma.GetUserApiResponse
 import xyz.funkybit.apps.api.model.tma.ReactionTimeApiRequest
-import xyz.funkybit.core.db.notifyDbListener
 import xyz.funkybit.core.model.telegram.TelegramUserId
 import xyz.funkybit.core.model.telegram.miniapp.TelegramMiniAppGoal
 import xyz.funkybit.core.model.telegram.miniapp.TelegramMiniAppUserEntity
@@ -24,6 +23,7 @@ import xyz.funkybit.core.model.telegram.miniapp.TelegramMiniAppUserIsBot
 import xyz.funkybit.core.model.telegram.miniapp.TelegramMiniAppUserRewardEntity
 import xyz.funkybit.core.utils.crPoints
 import xyz.funkybit.integrationtests.testutils.AppUnderTestRunner
+import xyz.funkybit.integrationtests.testutils.triggerRepeaterTaskAndWaitForCompletion
 import xyz.funkybit.integrationtests.utils.ApiCallFailure
 import xyz.funkybit.integrationtests.utils.TelegramMiniAppApiClient
 import xyz.funkybit.integrationtests.utils.assertError
@@ -517,10 +517,7 @@ class TelegramMiniAppApiTest {
             }
 
         // distribute referral rewards (3->2)
-        transaction {
-            notifyDbListener("repeater_app_task_ctl", "referral_points")
-        }
-        Thread.sleep(100L)
+        triggerRepeaterTaskAndWaitForCompletion("referral_points")
 
         lZeroInvitee.getUser().also {
             assertEquals("22".crPoints(), it.balance)
@@ -540,10 +537,7 @@ class TelegramMiniAppApiTest {
         }
 
         // distribute referral rewards (2->1)
-        transaction {
-            notifyDbListener("repeater_app_task_ctl", "referral_points")
-        }
-        Thread.sleep(100L)
+        triggerRepeaterTaskAndWaitForCompletion("referral_points")
 
         lZeroInvitee.getUser().also {
             assertEquals("22.2".crPoints(), it.balance)
@@ -563,10 +557,7 @@ class TelegramMiniAppApiTest {
         }
 
         // distribute referral rewards (1->0)
-        transaction {
-            notifyDbListener("repeater_app_task_ctl", "referral_points")
-        }
-        Thread.sleep(100L)
+        triggerRepeaterTaskAndWaitForCompletion("referral_points")
 
         lZeroInvitee.getUser().also {
             assertEquals("22.46".crPoints(), it.balance)
@@ -586,10 +577,7 @@ class TelegramMiniAppApiTest {
         }
 
         // distribute referral rewards (no changes)
-        transaction {
-            notifyDbListener("repeater_app_task_ctl", "referral_points")
-        }
-        Thread.sleep(100L)
+        triggerRepeaterTaskAndWaitForCompletion("referral_points")
 
         lZeroInvitee.getUser().also {
             assertEquals("22.46".crPoints(), it.balance)
@@ -619,10 +607,7 @@ class TelegramMiniAppApiTest {
         assertEquals("540".crPoints(), lThreeInvitee.getUser().balance)
 
         // distribute referral rewards (no one should get referral points from lThreeInvitee)
-        transaction {
-            notifyDbListener("repeater_app_task_ctl", "referral_points")
-        }
-        Thread.sleep(100L)
+        triggerRepeaterTaskAndWaitForCompletion("referral_points")
 
         lZeroInvitee.getUser().also {
             assertEquals("22.46".crPoints(), it.balance)

--- a/integrationtests/src/test/kotlin/xyz/funkybit/integrationtests/testutils/Repeater.kt
+++ b/integrationtests/src/test/kotlin/xyz/funkybit/integrationtests/testutils/Repeater.kt
@@ -1,0 +1,34 @@
+package xyz.funkybit.integrationtests.testutils
+
+import org.jetbrains.exposed.sql.transactions.TransactionManager
+import org.jetbrains.exposed.sql.transactions.transaction
+import xyz.funkybit.core.db.notifyDbListener
+import xyz.funkybit.core.repeater.REPEATER_APP_TASK_CTL_CHANNEL
+import xyz.funkybit.core.repeater.tasks.REPEATER_APP_TASK_DONE_CHANNEL
+import xyz.funkybit.core.utils.PgListener
+
+fun triggerRepeaterTaskAndWaitForCompletion(taskName: String, taskArgs: List<String> = emptyList()) {
+    var taskIsDone = false
+
+    val pgListener = PgListener(
+        TransactionManager.defaultDatabase!!,
+        "test_repeater_app_task_listener",
+        REPEATER_APP_TASK_DONE_CHANNEL,
+        {},
+    ) { notification ->
+        if (notification.parameter == taskName) {
+            taskIsDone = true
+        }
+    }
+    try {
+        pgListener.start()
+
+        transaction {
+            notifyDbListener(REPEATER_APP_TASK_CTL_CHANNEL, (listOf(taskName) + taskArgs).joinToString(":"))
+        }
+
+        waitFor { taskIsDone }
+    } finally {
+        pgListener.stop()
+    }
+}


### PR DESCRIPTION
Sometimes fails with:

```
org.opentest4j.AssertionFailedError: expected: <22.000000000000000000> but was: <20.000000000000000000>
	at app//org.junit.jupiter.api.AssertionFailureBuilder.build(AssertionFailureBuilder.java:151)
	at app//org.junit.jupiter.api.AssertionFailureBuilder.buildAndThrow(AssertionFailureBuilder.java:132)
	at app//org.junit.jupiter.api.AssertEquals.failNotEqual(AssertEquals.java:197)
	at app//org.junit.jupiter.api.AssertEquals.assertEquals(AssertEquals.java:182)
	at app//org.junit.jupiter.api.AssertEquals.assertEquals(AssertEquals.java:177)
	at app//org.junit.jupiter.api.Assertions.assertEquals(Assertions.java:1145)
	at app//xyz.funkybit.integrationtests.api.TelegramMiniAppApiTest.referralPoints(TelegramMiniAppApiTest.kt:526)
```

My assumption is that `Tread.sleep(100)` is sometimes too low of a delay for the repeater app task to finish. Waiting for a `notify` after the task has finished might be more reliable.