### PR TITLE
Make sure PgListener.start() blocks until listener has actually started running

### DIFF
--- a/backend/src/main/kotlin/xyz/funkybit/core/utils/PgListener.kt
+++ b/backend/src/main/kotlin/xyz/funkybit/core/utils/PgListener.kt
@@ -1,10 +1,12 @@
 package xyz.funkybit.core.utils
 
 import io.github.oshai.kotlinlogging.KotlinLogging
+import org.awaitility.kotlin.await
 import org.jetbrains.exposed.sql.Database
 import org.jetbrains.exposed.sql.statements.jdbc.JdbcConnectionImpl
 import org.postgresql.PGConnection
 import org.postgresql.PGNotification
+import java.time.Duration
 import kotlin.concurrent.thread
 
 class PgListener(
@@ -17,6 +19,7 @@ class PgListener(
     private var reconnectDebounceMs = 1000L
 
     private val logger = KotlinLogging.logger {}
+    private var isRunning: Boolean = false
 
     private val listener = thread(start = false, name = threadName) {
         logger.debug { "TID [${Thread.currentThread().id}] starting for $channel" }
@@ -25,6 +28,7 @@ class PgListener(
                 val listenerConn = (database.connector() as JdbcConnectionImpl).connection
                 val pgListenerConn = listenerConn.unwrap(PGConnection::class.java)
                 listenerConn.createStatement().also { it.execute("LISTEN $channel") }.close()
+                isRunning = true
                 try {
                     while (true) {
                         if (Thread.interrupted()) {
@@ -48,6 +52,7 @@ class PgListener(
                     try {
                         listenerConn.createStatement().also { it.execute("UNLISTEN $channel") }.close()
                         listenerConn.close()
+                        isRunning = false
                     } catch (t: Throwable) {
                         logger.error(t) { "Caught exception trying to unlisten from $channel" }
                     }
@@ -65,10 +70,19 @@ class PgListener(
         if (!listener.isAlive) {
             listener.start()
         }
+        await
+            .pollInSameThread()
+            .pollDelay(Duration.ofMillis(10))
+            .pollInterval(Duration.ofMillis(10))
+            .atMost(Duration.ofSeconds(30))
+            .until {
+                isRunning
+            }
     }
 
     fun stop() {
         listener.interrupt()
         listener.join()
+        isRunning = false
     }
 }


### PR DESCRIPTION
TMA referrals points test is still failing due to a race condition. This time it is Repeater app task that finishes before PgListener in the test actually subscribes to task completion events from Repeater.

```
2024-08-16 15:15:45 DEBUG PgListener TID:30, TN:"repeater_app_task-listener" - TID [30] repeater_app_task_ctl listener got 1 notifications
2024-08-16 15:15:45 DEBUG PgListener TID:30, TN:"repeater_app_task-listener" - TID [30] performing repeater_app_task-listener task for 'repeater_app_task_ctl' notification with param 'referral_points'
2024-08-16 15:15:45 DEBUG Repeater TID:30, TN:"repeater_app_task-listener" - Scheduling one time referral_points repeater task
2024-08-16 15:15:45 DEBUG PgListener TID:441, TN:"test_repeater_app_task_listener" - TID [441] starting for repeater_app_task_done

```