### PR TITLE
Fix 'connection.connector.getProvider is not a function' error in UI when opening the page with connected EVM wallet

### DIFF
--- a/web-ui/src/contexts/walletProvider.tsx
+++ b/web-ui/src/contexts/walletProvider.tsx
@@ -166,16 +166,18 @@ export function useWallet(): Wallet {
 
   const { connect, disconnect, changeAccount, bitcoinAccount, evmAccount } =
     context
+
   return {
     connect,
     disconnect,
     changeAccount,
     primaryAccount: evmAccount ?? bitcoinAccount,
-    primaryCategory: evmAccount?.isConnected
-      ? 'evm'
-      : bitcoinAccount?.address
-        ? 'bitcoin'
-        : 'none',
+    primaryCategory:
+      evmAccount?.status == 'connected'
+        ? 'evm'
+        : bitcoinAccount?.address
+          ? 'bitcoin'
+          : 'none',
     primaryAddress: evmAccount?.address ?? bitcoinAccount?.address,
     bitcoinAccount,
     evmAccount


### PR DESCRIPTION
During the initial load the `evmAccount.status` is in `reconnecting` state but `evmAccount.isConnected` is returning `true` 🤷 Because of this `signTypedData` was called before the connector is fully initialized and this resulted in a broken UI due to missing websocket connection.

<img width="592" alt="Screenshot 2024-08-26 at 14 57 01" src="https://github.com/user-attachments/assets/0a3b39c8-ae39-4b84-82b6-1b21d25a69b3">
