### PR TITLE
CHAIN-486 check bitcoin address matches signature

### DIFF
--- a/backend/src/main/kotlin/xyz/funkybit/core/model/Address.kt
+++ b/backend/src/main/kotlin/xyz/funkybit/core/model/Address.kt
@@ -67,7 +67,7 @@ sealed class BitcoinAddress(val value: String) : Address() {
         this.value.startsWith("3") -> P2SH(this.value, false)
         this.value.startsWith("2") -> P2SH(this.value, true)
         this.value.startsWith("1") -> P2PKH(this.value, false)
-        this.value.startsWith("m") -> P2PKH(this.value, true)
+        this.value.startsWith("m") || this.value.startsWith("n") -> P2PKH(this.value, true)
         else -> Unrecognized(this.value)
     }
     override fun toString() = this.value

--- a/backend/src/main/kotlin/xyz/funkybit/core/model/BitcoinSignature.kt
+++ b/backend/src/main/kotlin/xyz/funkybit/core/model/BitcoinSignature.kt
@@ -1,26 +1,19 @@
 package xyz.funkybit.core.model
 
 import kotlinx.serialization.Serializable
-import xyz.funkybit.core.utils.toHex
-import xyz.funkybit.core.utils.toHexBytes
+import kotlin.io.encoding.Base64
+import kotlin.io.encoding.ExperimentalEncodingApi
 
 @Serializable
 @JvmInline
 value class BitcoinSignature(val value: String) {
-    init {
-        require(
-            // TODO check length and format
-            true,
-        ) {
-            "Invalid bitcoin signature format"
-        }
-    }
-
-    fun toByteArray() = value.toHexBytes()
 
     companion object {
+        @OptIn(ExperimentalEncodingApi::class, ExperimentalStdlibApi::class)
         fun emptySignature(): BitcoinSignature {
-            return ByteArray(65).toHex().toBitcoinSignature()
+            return BitcoinSignature(
+                value = Base64.encode("0".repeat(130).hexToByteArray()),
+            )
         }
     }
 }

--- a/backend/src/main/kotlin/xyz/funkybit/core/utils/bitcoin/BitcoinSignatureVerification.kt
+++ b/backend/src/main/kotlin/xyz/funkybit/core/utils/bitcoin/BitcoinSignatureVerification.kt
@@ -60,7 +60,7 @@ object BitcoinSignatureVerification {
 
             when (address) {
                 is BitcoinAddress.P2PKH -> {
-                    // transaction is pay-2-public-key-hash, therefore comparing a hash of the recovered from the signature public key
+                    // comparing a hash of the recovered from the signature public key
                     val p2PKHAddress = LegacyAddress.fromPubKeyHash(getParams(), recoveredPubkey.pubKeyHash)
 
                     return p2PKHAddress.toBase58() == address.value

--- a/backend/src/main/kotlin/xyz/funkybit/core/utils/bitcoin/BitcoinSignatureVerification.kt
+++ b/backend/src/main/kotlin/xyz/funkybit/core/utils/bitcoin/BitcoinSignatureVerification.kt
@@ -1,7 +1,6 @@
 package xyz.funkybit.core.utils.bitcoin
 
 import io.github.oshai.kotlinlogging.KotlinLogging
-import org.bitcoinj.core.Base58
 import org.bitcoinj.core.Coin
 import org.bitcoinj.core.ECKey
 import org.bitcoinj.core.LegacyAddress
@@ -165,12 +164,6 @@ object BitcoinSignatureVerification {
                 else -> throw IllegalArgumentException("Only P2WPKH and P2TR addresses are supported")
             }
         }
-    }
-
-    fun base58Check(addrType: Int, payload: ByteArray): String {
-        val addressBytes = byteArrayOf(addrType.toByte()) + payload
-        val checksum = doubleSha256(addressBytes).copyOfRange(0, 4)
-        return Base58.encode(addressBytes + checksum)
     }
 
     @OptIn(ExperimentalStdlibApi::class)

--- a/backend/src/test/kotlin/xyz/funkybit/core/bitcoin/SignatureVerification.kt
+++ b/backend/src/test/kotlin/xyz/funkybit/core/bitcoin/SignatureVerification.kt
@@ -24,13 +24,33 @@ class SignatureVerification {
 
     @Test
     fun `test P2PKH signature verification`() {
-        val address = "1EgGNqPsJLXHgnHHgUQEP63vU4DJKEkpiq"
+        // address representation of public key hash
+        // mainnet: "1EgGNqPsJLXHgnHHgUQEP63vU4DJKEkpiq"
+        // testnet: "muCDftUr7MxYTtkuQ3NcD1GFL3p18jEQU8"
+
+        // supply testnet address so that verification succeeds, later signature should be updated due to message change
+        val address = "muCDftUr7MxYTtkuQ3NcD1GFL3p18jEQU8"
         val messageToSign = "[funkybit] Please sign this message to verify your ownership of this wallet address. This action will not cost any gas fees.\n" +
             "Address: 1EgGNqPsJLXHgnHHgUQEP63vU4DJKEkpiq, Timestamp: 2024-08-21T14:20:17.358Z"
         val signature = "IH8bsp/iwsft8DvqD6I6aq0rt2dr2spQAl4Y7udt19N1Wl+v5djary8UxXs+rAErvvY/niYxURJJAd2rukydNCg="
         assertTrue(
             BitcoinSignatureVerification.verifyMessage(
                 BitcoinAddress.canonicalize(address),
+                signature,
+                messageToSign,
+            ),
+        )
+    }
+
+    @Test
+    fun `test segwit 65-bytes signature verification`() {
+        val address = BitcoinAddress.canonicalize("bcrt1qmasw66mddrrkwdumd24lece7hslyy303xwk8nv")
+        val messageToSign = "[funkybit] Please sign this message to verify your ownership of this wallet address. This action will not cost any gas fees.\nAddress: bcrt1qmasw66mddrrkwdumd24lece7hslyy303xwk8nv, Timestamp: 2024-08-19T20:22:52.523Z"
+        val signature = "IBfCHqORRWn4cMSzC4+Vt8DDmFLf64hkW0DDfZxDa0hOX9esApXWZvOECDVmG2adny8Z3NebIhmC6zhN3HTTTdc="
+
+        assertTrue(
+            BitcoinSignatureVerification.verifyMessage(
+                address,
                 signature,
                 messageToSign,
             ),

--- a/integrationtests/src/test/kotlin/xyz/funkybit/integrationtests/api/WalletLinkingTest.kt
+++ b/integrationtests/src/test/kotlin/xyz/funkybit/integrationtests/api/WalletLinkingTest.kt
@@ -136,14 +136,14 @@ class WalletLinkingTest : OrderBaseTest() {
         evmKeyApiClient.tryLinkWallets(
             LinkWalletsApiRequest(
                 bitcoinLinkAddressProof = signBitcoinWalletLinkProof(
-                    ecKey = bitcoinKey,
-                    address = bitcoinAddress,
-                    linkAddress = evmAddress,
+                    ecKey = bitcoinKeyApiClient.keyPair.asECKey(),
+                    address = bitcoinKeyApiClient.address.asBitcoinAddress(),
+                    linkAddress = evmKeyApiClient.address.asEvmAddress(),
                 ).copy(signature = BitcoinSignature("H7P1/r+gULX05tXwaJGfglZSL4sRhykAsgwQtpm92xRIPaGUnxQAhm1CZsTuQ8wh3w51f1uUVpxU2RUfJ3hq81I=")),
                 evmLinkAddressProof = signEvmWalletLinkProof(
-                    ecKeyPair = evmWalletKeyPair.ecKeyPair,
-                    address = evmAddress,
-                    linkAddress = bitcoinAddress,
+                    ecKeyPair = evmKeyApiClient.keyPair.asEcKeyPair(),
+                    address = evmKeyApiClient.address.asEvmAddress(),
+                    linkAddress = bitcoinKeyApiClient.address.asBitcoinAddress(),
                 ),
             ),
         ).assertError(ApiError(ReasonCode.LinkWalletsError, "Signature can't be verified"))


### PR DESCRIPTION
Check that claimed address (sign-in, link messages) matches the address recovered from the signature. 

P2PKH verification is straightforward. 

P2SH is weird because we construct 1 of 1 scriptSig with the provided address and then check is script hash matches recovered value. Other multisig options will fail because we do not have original script.
