### PR TITLE
CHAIN-514 improve withdrawal UX in CTA

### DIFF
--- a/web-ui/src/apiClient.ts
+++ b/web-ui/src/apiClient.ts
@@ -505,7 +505,11 @@ const PointTypeSchema = z.enum([
   'DailyReward',
   'WeeklyReward',
   'OverallReward',
-  'ReferralBonus'
+  'ReferralBonus',
+  'EvmWalletConnected',
+  'EvmWithdrawalDeposit',
+  'BitcoinWalletConnected',
+  'BitcoinWithdrawalDeposit'
 ])
 
 const RewardCategorySchema = z.enum([

--- a/web-ui/src/apiClient.ts
+++ b/web-ui/src/apiClient.ts
@@ -165,7 +165,8 @@ export const AccountConfigurationApiResponseSchema = z.object({
     }),
   nickName: z.string().nullable(),
   avatarUrl: z.string().nullable(),
-  inviteCode: z.string()
+  inviteCode: z.string(),
+  pointsBalance: decimal()
 })
 export type AccountConfigurationApiResponse = z.infer<
   typeof AccountConfigurationApiResponseSchema

--- a/web-ui/src/components/Screens/Header.tsx
+++ b/web-ui/src/components/Screens/Header.tsx
@@ -17,6 +17,7 @@ import { useConfig } from 'wagmi'
 import { useAuth } from 'contexts/auth'
 
 export type Tab = 'Swap' | 'Limit' | 'Dashboard' | 'Testnet Challenge'
+export type Widget = 'Balances'
 
 export function Header({
   tab,
@@ -28,7 +29,7 @@ export function Header({
   tab: Tab
   markets: Markets
   isAdmin: boolean
-  onTabChange: (newTab: Tab) => void
+  onTabChange: (newTab: Tab, widget?: Widget) => void
   onShowAdmin: () => void
 }) {
   const { isAuthenticated } = useAuth()

--- a/web-ui/src/components/Screens/HomeScreen/testnetchallenge/Leaderboard.tsx
+++ b/web-ui/src/components/Screens/HomeScreen/testnetchallenge/Leaderboard.tsx
@@ -31,6 +31,7 @@ import { Tooltip } from 'react-tooltip'
 import { accountConfigQueryKey } from 'components/Screens/HomeScreen'
 import TradingSymbol from 'tradingSymbol'
 import TradingSymbols from 'tradingSymbols'
+import Decimal from 'decimal.js'
 
 type EditMode = 'none' | 'name' | 'icon'
 
@@ -315,6 +316,7 @@ function CardCarousel({
 }
 
 export function Leaderboard({
+  pointsBalance,
   avatarUrl,
   nickName,
   inviteCode,
@@ -324,6 +326,7 @@ export function Leaderboard({
   onChangeTab,
   onWithdrawal
 }: {
+  pointsBalance: Decimal
   avatarUrl?: string
   nickName?: string
   inviteCode: string
@@ -548,7 +551,10 @@ export function Leaderboard({
                 )}
               </div>
               <div className="text-sm">
-                funky bits: <span className="text-statusOrange">23,500</span>
+                funky bits:{' '}
+                <span className="text-statusOrange">
+                  {pointsBalance.toFixed(0)}
+                </span>
               </div>
               <div className="flex flex-row pt-2">
                 <Button

--- a/web-ui/src/components/Screens/HomeScreen/testnetchallenge/TestnetChallengeTab.tsx
+++ b/web-ui/src/components/Screens/HomeScreen/testnetchallenge/TestnetChallengeTab.tsx
@@ -1,7 +1,9 @@
 import {
   AccountConfigurationApiResponse,
   AddressType,
-  apiClient
+  apiClient,
+  Balance,
+  Chain
 } from 'apiClient'
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
@@ -9,7 +11,7 @@ import TradingSymbol from 'tradingSymbol'
 import { useSwitchToEthChain } from 'utils/switchToEthChain'
 import { useConfig } from 'wagmi'
 import TradingSymbols from 'tradingSymbols'
-import { useWallets } from 'contexts/walletProvider'
+import { ConnectedWallet, useWallets } from 'contexts/walletProvider'
 import ZeppelinSvg from 'assets/zeppelin.svg'
 import PointRightSvg from 'assets/point-right.svg'
 import StopHandSvg from 'assets/stop-hand.svg'
@@ -17,24 +19,48 @@ import ClockSvg from 'assets/clock.svg'
 import DiscoBall from 'components/Screens/HomeScreen/DiscoBall'
 import DepositModal from 'components/Screens/HomeScreen/DepositModal'
 import { Leaderboard } from 'components/Screens/HomeScreen/testnetchallenge/Leaderboard'
-import { Tab } from 'components/Screens/Header'
+import { Tab, Widget } from 'components/Screens/Header'
 import { accountConfigQueryKey } from 'components/Screens/HomeScreen'
+import { useWebsocketSubscription } from 'contexts/websocket'
+import { balancesTopic, Publishable } from 'websocketMessages'
+import WithdrawalModal from 'components/Screens/HomeScreen/WithdrawalModal'
 
 export const testnetChallengeInviteCodeKey = 'testnetChallengeInviteCode'
 export function TestnetChallengeTab({
+  chains,
   symbols,
   exchangeContract,
   accountConfig,
   onChangeTab
 }: {
+  chains: Chain[]
   symbols: TradingSymbols
   exchangeContract?: { name: string; address: string }
   accountConfig?: AccountConfigurationApiResponse
-  onChangeTab: (tab: Tab) => void
+  onChangeTab: (tab: Tab, widget?: Widget) => void
 }) {
   const evmConfig = useConfig()
   const queryClient = useQueryClient()
   const wallets = useWallets()
+
+  const [balances, setBalances] = useState<Balance[]>(() => [])
+  useWebsocketSubscription({
+    topics: useMemo(() => [balancesTopic], []),
+    handler: useCallback(
+      (message: Publishable) => {
+        if (message.type === 'Balances') {
+          setBalances(message.balances)
+          queryClient.invalidateQueries({ queryKey: accountConfigQueryKey })
+        }
+      },
+      [queryClient]
+    )
+  })
+  const [showWithdrawalModal, setShowWithdrawalModal] = useState(false)
+  const [withdrawalWallet, setWithdrawalWallet] = useState<ConnectedWallet>()
+  const [withdrawalSymbol, setWithdrawalSymbol] = useState<TradingSymbol>()
+  const [withdrawalExchangeContract, setWithdrawalExchangeContract] =
+    useState<AddressType>()
 
   const [
     showTestnetChallengeDepositModal,
@@ -157,6 +183,33 @@ export function TestnetChallengeTab({
     }
   }, [wallets, walletHasConnected, queryClient])
 
+  function onWithdrawal(symbol: TradingSymbol) {
+    if (wallets.isConnected(symbol.networkType)) {
+      setWithdrawalWallet(
+        wallets.connected.find(
+          (wallet) => wallet.networkType == symbol.networkType
+        )
+      )
+      setWithdrawalSymbol(symbol)
+
+      if (symbol.networkType === 'Bitcoin') {
+        const contractAddress = chains
+          .filter((chain) => chain.networkType === 'Bitcoin')[0]
+          .contracts.find((c) => c.name == 'Exchange')?.address
+
+        setWithdrawalExchangeContract(contractAddress)
+      } else if (symbol.networkType === 'Evm') {
+        const contractAddress = chains
+          .filter((chain) => chain.networkType === 'Evm')
+          .find((chain) => chain.id === symbol.chainId)!
+          .contracts.find((c) => c.name == 'Exchange')?.address
+
+        setWithdrawalExchangeContract(contractAddress)
+      }
+      setShowWithdrawalModal(true)
+    }
+  }
+
   return (
     <>
       <div className="flex h-[85vh] flex-col">
@@ -168,7 +221,10 @@ export function TestnetChallengeTab({
                 nickName={nickName}
                 inviteCode={inviteCode}
                 wallets={wallets}
+                balances={balances}
+                symbols={symbols}
                 onChangeTab={onChangeTab}
+                onWithdrawal={onWithdrawal}
               />
             ) : (
               <div className="col-span-1 laptop:col-span-3">
@@ -321,6 +377,27 @@ export function TestnetChallengeTab({
               message={
                 'You now have $10,000 of tUSDC in your wallet, click Submit to deposit it to funkybit.'
               }
+            />
+          )}
+        {withdrawalWallet?.address &&
+          withdrawalExchangeContract &&
+          withdrawalSymbol &&
+          (withdrawalSymbol.networkType === 'Bitcoin' ||
+            withdrawalSymbol?.chainId === evmConfig.state.chainId) && (
+            <WithdrawalModal
+              exchangeContractAddress={withdrawalExchangeContract}
+              walletAddress={withdrawalWallet.address}
+              symbol={withdrawalSymbol}
+              isOpen={showWithdrawalModal}
+              close={() => setShowWithdrawalModal(false)}
+              onClosed={() => {
+                setWithdrawalWallet(undefined)
+                setWithdrawalSymbol(undefined)
+                setWithdrawalExchangeContract(undefined)
+                queryClient.invalidateQueries({
+                  queryKey: accountConfigQueryKey
+                })
+              }}
             />
           )}
       </div>

--- a/web-ui/src/components/Screens/HomeScreen/testnetchallenge/TestnetChallengeTab.tsx
+++ b/web-ui/src/components/Screens/HomeScreen/testnetchallenge/TestnetChallengeTab.tsx
@@ -95,18 +95,24 @@ export function TestnetChallengeTab({
     }
   })
 
-  const { testnetChallengeStatus, nickName, avatarUrl, inviteCode } =
-    useMemo(() => {
-      if (accountConfig) {
-        return {
-          testnetChallengeStatus: accountConfig.testnetChallengeStatus,
-          nickName: accountConfig.nickName ?? undefined,
-          avatarUrl: accountConfig.avatarUrl ?? undefined,
-          inviteCode: accountConfig.inviteCode
-        }
+  const {
+    testnetChallengeStatus,
+    nickName,
+    avatarUrl,
+    inviteCode,
+    pointsBalance
+  } = useMemo(() => {
+    if (accountConfig) {
+      return {
+        testnetChallengeStatus: accountConfig.testnetChallengeStatus,
+        nickName: accountConfig.nickName ?? undefined,
+        avatarUrl: accountConfig.avatarUrl ?? undefined,
+        inviteCode: accountConfig.inviteCode,
+        pointsBalance: accountConfig.pointsBalance
       }
-      return {}
-    }, [accountConfig])
+    }
+    return {}
+  }, [accountConfig])
 
   const accountRefreshRef = useRef<NodeJS.Timeout | null>(null)
 
@@ -217,6 +223,7 @@ export function TestnetChallengeTab({
           <div className="grid h-full w-screen min-w-[1250px] grid-cols-1 gap-2 px-4 text-lg text-white narrow:grid-cols-3">
             {testnetChallengeStatus === 'Enrolled' ? (
               <Leaderboard
+                pointsBalance={pointsBalance}
                 avatarUrl={avatarUrl}
                 nickName={nickName}
                 inviteCode={inviteCode}


### PR DESCRIPTION
 - direct withdrawal when single asset
 - navigate (and scroll) to balances when multiple assets
 - navigate (and scroll) to balances when respective wallet is not connected
 - show real points balance in UI


==== single asset


https://github.com/user-attachments/assets/cbea4f6b-82e5-413a-8c4e-416e195510ca





==== multiple asset

https://github.com/user-attachments/assets/feb73973-6b9a-4095-ac2b-b9815bb3f37f


