### PR TITLE
CHAIN-521 disconnect wallet on address change

### DIFF
--- a/web-ui/src/contexts/walletProvider.tsx
+++ b/web-ui/src/contexts/walletProvider.tsx
@@ -244,6 +244,19 @@ function WalletProviderInternal({ children }: { children: React.ReactNode }) {
   // handle EVM wallet connect/disconnect events
   useEffect(() => {
     async function onConnected() {
+      // disconnect all wallets if the primary evm wallet address has changed
+      if (
+        primaryWallet &&
+        primaryWallet.networkType === 'Evm' &&
+        primaryWallet.address !== evmAccount.address
+      ) {
+        await disconnectWallet('Evm')
+
+        if (bitcoinAccount != null) {
+          await disconnectWallet('Bitcoin')
+        }
+      }
+
       switch (primaryWallet?.networkType) {
         case undefined:
         case null:


### PR DESCRIPTION
- On EVM wallet address change:
  - If the EVM wallet is the primary, disconnect all wallets
  - If the Bitcoin wallet is the primary, disconnect only the EVM wallet