### PR TITLE
fix for sporadic deposit failure in arch on CI

### DIFF
--- a/.github/workflows/build-push-backend.yml
+++ b/.github/workflows/build-push-backend.yml
@@ -33,7 +33,8 @@ jobs:
         env:
           CI_RUN: 1
           CRYPTOCOMPARE_API_KEY: ${{ secrets.CRYPTOCOMPARE_API_KEY }}
-          BITCOIN_NETWORK_ENABLED: "false"
+          BITCOIN_NETWORK_ENABLED: "true"
+          WAIT_FOR_ARCH_DEPLOYMENT: "true"
       - name: Test Report
         uses: dorny/test-reporter@v1.8.0
         if: success() || failure()

--- a/backend/src/main/kotlin/xyz/funkybit/apps/api/model/Deposit.kt
+++ b/backend/src/main/kotlin/xyz/funkybit/apps/api/model/Deposit.kt
@@ -37,7 +37,7 @@ data class Deposit(
                 Symbol(entity.symbol.name),
                 entity.amount,
                 when (entity.status) {
-                    DepositStatus.Pending, DepositStatus.Confirmed, DepositStatus.Settling, DepositStatus.SentToSequencer -> Status.Pending
+                    DepositStatus.Pending, DepositStatus.Confirmed, DepositStatus.Settling, DepositStatus.SentToSequencer, DepositStatus.SentToArch -> Status.Pending
                     DepositStatus.Complete -> Status.Complete
                     DepositStatus.Failed -> Status.Failed
                 },

--- a/backend/src/main/kotlin/xyz/funkybit/core/db/Migrations.kt
+++ b/backend/src/main/kotlin/xyz/funkybit/core/db/Migrations.kt
@@ -95,6 +95,7 @@ import xyz.funkybit.core.model.db.migrations.V93_AddBitcoinUtxoTable
 import xyz.funkybit.core.model.db.migrations.V94_UpdateArchAccountTable
 import xyz.funkybit.core.model.db.migrations.V95_AddIndexToBroadcasterJobTable
 import xyz.funkybit.core.model.db.migrations.V96_UpdateBitcoinUtxoTable
+import xyz.funkybit.core.model.db.migrations.V97_AddSentToArchStatusToDeposit
 import xyz.funkybit.core.model.db.migrations.V9_SymbolTable
 
 val migrations = listOf(
@@ -194,4 +195,5 @@ val migrations = listOf(
     V94_UpdateArchAccountTable(),
     V95_AddIndexToBroadcasterJobTable(),
     V96_UpdateBitcoinUtxoTable(),
+    V97_AddSentToArchStatusToDeposit(),
 )

--- a/backend/src/main/kotlin/xyz/funkybit/core/model/db/Deposit.kt
+++ b/backend/src/main/kotlin/xyz/funkybit/core/model/db/Deposit.kt
@@ -39,6 +39,7 @@ enum class DepositStatus {
     Complete,
     Failed,
     Settling,
+    SentToArch,
     ;
 
     fun isFinal(): Boolean {
@@ -98,9 +99,18 @@ class DepositEntity(guid: EntityID<DepositId>) : GUIDEntity<DepositId>(guid) {
         fun getSettlingForUpdate(chainId: ChainId): List<DepositEntity> =
             getForUpdate(chainId, DepositStatus.Settling)
 
-        fun updateToSettling(depositEntities: List<DepositEntity>, blockchainTransactionEntity: BlockchainTransactionEntity) {
+        fun getSentToArchForUpdate(chainId: ChainId): List<DepositEntity> =
+            getForUpdate(chainId, DepositStatus.SentToArch)
+
+        fun updateToSentToArch(depositEntities: List<DepositEntity>, blockchainTransactionEntity: BlockchainTransactionEntity) {
             DepositTable.update({ DepositTable.guid.inList(depositEntities.map { it.guid }) }) {
                 it[archTransactionGuid] = blockchainTransactionEntity.guid
+                it[status] = DepositStatus.SentToArch
+            }
+        }
+
+        fun updateToSettling(depositEntities: List<DepositEntity>) {
+            DepositTable.update({ DepositTable.guid.inList(depositEntities.map { it.guid }) }) {
                 it[status] = DepositStatus.Settling
             }
         }

--- a/backend/src/main/kotlin/xyz/funkybit/core/model/db/migrations/V97_AddSentToArchStatusToDeposit.kt
+++ b/backend/src/main/kotlin/xyz/funkybit/core/model/db/migrations/V97_AddSentToArchStatusToDeposit.kt
@@ -1,0 +1,39 @@
+package xyz.funkybit.core.model.db.migrations
+
+import org.jetbrains.exposed.sql.transactions.transaction
+import xyz.funkybit.core.db.Migration
+import xyz.funkybit.core.db.updateEnum
+import xyz.funkybit.core.model.db.DepositId
+import xyz.funkybit.core.model.db.GUIDTable
+import xyz.funkybit.core.model.db.PGEnum
+
+@Suppress("ClassName")
+class V97_AddSentToArchStatusToDeposit : Migration() {
+
+    @Suppress("ClassName")
+    enum class V97_DepositStatus {
+        Pending,
+        Confirmed,
+        SentToSequencer,
+        Complete,
+        Failed,
+        Settling,
+        SentToArch,
+    }
+
+    @Suppress("ClassName")
+    object V97_DepositTable : GUIDTable<DepositId>("deposit", ::DepositId) {
+        val status = customEnumeration(
+            "status",
+            "DepositStatus",
+            { value -> V97_DepositStatus.valueOf(value as String) },
+            { PGEnum("DepositStatus", it) },
+        ).index()
+    }
+
+    override fun run() {
+        transaction {
+            updateEnum<V97_DepositStatus>(listOf(V97_DepositTable.status), "DepositStatus")
+        }
+    }
+}


### PR DESCRIPTION
the primary issue was for arch we have an extra state since we need to send a tx to arch after we detect the deposits on chain, but that was not represented by a separate state in the model - it just used `Settling` - this adds a different state to represent that state to represent when it has been `SentToArch` and it only goes to `Settling` after arch has processed the tx. The lack of a separate state led to some sporadic failures since we were updating tables in the arch transaction handler and calling the sequencer in the same transaction and sometimes the sequencer response processor would run and complete it's tx, before the arch transaction handler completed it's tx which led to some sporadic test failures.