### PR TITLE
Reduce HTTP calls logging from background workers that are just polling data from chain

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ test:
 	./gradlew test
 
 run_backend:
-	QUIET_MODE=true ./gradlew :run
+	./gradlew :run
 
 run_sequencer:
 	SANDBOX_MODE=true ECO_MODE=true ./gradlew :sequencer:run

--- a/backend/src/main/kotlin/xyz/funkybit/apps/ring/BitcoinDepositHandler.kt
+++ b/backend/src/main/kotlin/xyz/funkybit/apps/ring/BitcoinDepositHandler.kt
@@ -8,6 +8,7 @@ import xyz.funkybit.core.blockchain.bitcoin.MempoolSpaceClient
 import xyz.funkybit.core.blockchain.bitcoin.bitcoinConfig
 import xyz.funkybit.core.model.db.DeployedSmartContractEntity
 import xyz.funkybit.core.model.db.DepositEntity
+import xyz.funkybit.core.utils.HttpClient
 import java.math.BigInteger
 import kotlin.concurrent.thread
 import kotlin.time.Duration
@@ -38,6 +39,9 @@ class BitcoinDepositHandler(
 
         workerThread = thread(start = true, name = "deposit-confirmation-handler-$chainId", isDaemon = true) {
             logger.debug { "Deposit confirmation handler thread starting for $chainId" }
+
+            HttpClient.setQuietModeForThread(true)
+
             while (true) {
                 try {
                     Thread.sleep(pollingIntervalInMs)
@@ -61,6 +65,7 @@ class BitcoinDepositHandler(
     }
 
     private fun refreshPendingDeposit(pendingDeposit: DepositEntity, currentBlockHeight: Long) {
+        logger.info { "Refreshing pending deposit ${pendingDeposit.guid}, currentBlockHeight=$currentBlockHeight" }
         val tx = MempoolSpaceClient.getTransaction(pendingDeposit.transactionHash)
         if (pendingDeposit.blockNumber == null && tx?.status?.confirmed == true && tx.status.blockHeight != null) {
             pendingDeposit.updateBlockNumber(tx.status.blockHeight.toBigInteger())
@@ -79,7 +84,7 @@ class BitcoinDepositHandler(
                 pendingDeposit.amount = onChainAmount
             }
 
-            pendingDeposit.updateBlockNumber((tx.status.blockHeight ?: 0).toBigInteger())
+            pendingDeposit.updateBlockNumber(tx.status.blockHeight.toBigInteger())
             pendingDeposit.markAsConfirmed()
         } else if (Clock.System.now() - pendingDeposit.createdAt > maxWaitTime) {
             pendingDeposit.markAsFailed("Deposit not confirmed within $maxWaitTime", canBeResubmitted = true)

--- a/backend/src/main/kotlin/xyz/funkybit/core/blockchain/bitcoin/ArchNetworkClient.kt
+++ b/backend/src/main/kotlin/xyz/funkybit/core/blockchain/bitcoin/ArchNetworkClient.kt
@@ -12,13 +12,13 @@ import xyz.funkybit.core.model.rpc.ArchRpcRequest
 
 object ArchNetworkClient : JsonRpcClientBase(
     System.getenv("ARCH_NETWORK_RPC_URL") ?: "http://localhost:9002",
+    KotlinLogging.logger {},
     null,
 ) {
 
     const val MAX_TX_SIZE = 1024
     const val MAX_INSTRUCTION_SIZE = MAX_TX_SIZE - 103 // version (4), 1 signer (33), 1 signature (65), 1 byte for instruction count
 
-    override val logger = KotlinLogging.logger {}
     override val mediaType = "application/json".toMediaTypeOrNull()
 
     fun getAccountAddress(pubKey: ArchNetworkRpc.Pubkey): BitcoinAddress {
@@ -73,8 +73,8 @@ object ArchNetworkClient : JsonRpcClientBase(
         )
     }
 
-    inline fun <reified T> getValue(request: ArchRpcRequest, logResponseBody: Boolean = true): T {
-        val jsonElement = call(json.encodeToString(request), logResponseBody)
+    inline fun <reified T> getValue(request: ArchRpcRequest): T {
+        val jsonElement = call(json.encodeToString(request))
         return json.decodeFromJsonElement(jsonElement)
     }
 }

--- a/backend/src/main/kotlin/xyz/funkybit/core/blockchain/bitcoin/BitcoinClient.kt
+++ b/backend/src/main/kotlin/xyz/funkybit/core/blockchain/bitcoin/BitcoinClient.kt
@@ -12,6 +12,7 @@ import java.math.BigInteger
 
 object BitcoinClient : JsonRpcClientBase(
     System.getenv("BITCOIN_NETWORK_RPC_URL") ?: "http://localhost:18443/wallet/testwallet",
+    KotlinLogging.logger {},
     if ((System.getenv("BITCOIN_NETWORK_ENABLE_BASIC_AUTH") ?: "true").toBoolean()) {
         BasicAuthInterceptor(
             System.getenv("BITCOIN_NETWORK_RPC_USER") ?: "user",
@@ -22,7 +23,6 @@ object BitcoinClient : JsonRpcClientBase(
     },
 ) {
 
-    override val logger = KotlinLogging.logger {}
     private val faucetAddress = BitcoinAddress.canonicalize(System.getenv("BITCOIN_FAUCET_ADDRESS") ?: "bcrt1q3nyukkpkg6yj0y5tj6nj80dh67m30p963mzxy7")
 
     fun mine(nBlocks: Int): List<String> {
@@ -32,7 +32,6 @@ object BitcoinClient : JsonRpcClientBase(
                     "generatetoaddress",
                     BitcoinRpcParams(listOf(nBlocks, faucetAddress)),
                 ),
-                noLog = true,
             )
         } catch (e: Exception) {
             listOf()
@@ -50,8 +49,8 @@ object BitcoinClient : JsonRpcClientBase(
         }
     }
 
-    inline fun <reified T> getValue(request: BitcoinRpcRequest, logResponseBody: Boolean = true, noLog: Boolean = false): T {
-        val jsonElement = call(json.encodeToString(request), logResponseBody, noLog)
+    inline fun <reified T> getValue(request: BitcoinRpcRequest): T {
+        val jsonElement = call(json.encodeToString(request))
         return json.decodeFromJsonElement(jsonElement)
     }
 }

--- a/backend/src/main/kotlin/xyz/funkybit/core/repeater/Repeater.kt
+++ b/backend/src/main/kotlin/xyz/funkybit/core/repeater/Repeater.kt
@@ -1,6 +1,7 @@
 package xyz.funkybit.core.repeater
 
 import io.github.oshai.kotlinlogging.KotlinLogging
+import org.apache.commons.lang3.concurrent.BasicThreadFactory
 import org.jetbrains.exposed.sql.Database
 import xyz.funkybit.core.repeater.tasks.ArchTokenStateSetupTask
 import xyz.funkybit.core.repeater.tasks.BroadcasterJobsCleanupTask
@@ -32,7 +33,7 @@ class Repeater(db: Database, private val automaticTaskScheduling: Boolean = true
         ProgramUtxoRefresherTask(),
     ).associateBy { it.name }
 
-    private val timer = ScheduledThreadPoolExecutor(8)
+    private val timer = ScheduledThreadPoolExecutor(8, BasicThreadFactory.Builder().namingPattern("repeater-pool-%d").build())
 
     private val pgListener = PgListener(db, "repeater_app_task-listener", REPEATER_APP_TASK_CTL_CHANNEL, {}) { notification ->
         var repeaterTaskName = notification.parameter

--- a/backend/src/main/kotlin/xyz/funkybit/core/repeater/tasks/ProgramUtxoRefresherTask.kt
+++ b/backend/src/main/kotlin/xyz/funkybit/core/repeater/tasks/ProgramUtxoRefresherTask.kt
@@ -6,6 +6,7 @@ import xyz.funkybit.core.blockchain.bitcoin.bitcoinConfig
 import xyz.funkybit.core.model.BitcoinAddress
 import xyz.funkybit.core.model.db.DeployedSmartContractEntity
 import xyz.funkybit.core.services.UtxoManager
+import xyz.funkybit.core.utils.HttpClient
 import kotlin.time.Duration.Companion.seconds
 
 class ProgramUtxoRefresherTask : RepeaterBaseTask(
@@ -16,10 +17,17 @@ class ProgramUtxoRefresherTask : RepeaterBaseTask(
     override val name: String = "program_utxo_refresher"
 
     override fun runWithLock() {
-        transaction {
-            DeployedSmartContractEntity.validContracts(bitcoinConfig.chainId).firstOrNull()?.let {
-                UtxoManager.refreshUtxos(it.proxyAddress as BitcoinAddress)
+        try {
+            logger.info { "Refreshing program UTXOs" }
+            HttpClient.setQuietModeForThread(true)
+
+            transaction {
+                DeployedSmartContractEntity.validContracts(bitcoinConfig.chainId).firstOrNull()?.let {
+                    UtxoManager.refreshUtxos(it.proxyAddress as BitcoinAddress)
+                }
             }
+        } finally {
+            HttpClient.setQuietModeForThread(false)
         }
     }
 }

--- a/backend/src/main/kotlin/xyz/funkybit/core/repeater/tasks/RepeaterBaseTask.kt
+++ b/backend/src/main/kotlin/xyz/funkybit/core/repeater/tasks/RepeaterBaseTask.kt
@@ -34,12 +34,12 @@ abstract class RepeaterBaseTask(
                     notifyDbListener(REPEATER_APP_TASK_DONE_CHANNEL, name)
                 }
             } catch (t: Throwable) {
-                logger.error(t) { "Error running ${this.javaClass.simpleName}" }
+                logger.error(t) { "Error running repeater task $name" }
             } finally {
                 maxPlannedExecutionTime?.let { maxExecutionTime ->
                     val executionTime = Clock.System.now() - startTime
                     if (executionTime > maxExecutionTime) {
-                        logger.error { "The execution time of ${this.javaClass.simpleName} ($executionTime) has exceeded the maximum planned time ($maxExecutionTime). Please consider optimizing it." }
+                        logger.error { "The execution time of repeater task $name ($executionTime) has exceeded the maximum planned time ($maxExecutionTime). Please consider optimizing it." }
                     }
                 }
                 try {
@@ -54,7 +54,7 @@ abstract class RepeaterBaseTask(
                 }
             }
         } else {
-            logger.warn { "Could not acquire lock for ${this.javaClass.simpleName}, skipping" }
+            logger.warn { "Could not acquire lock for repeater task $name, skipping" }
         }
     }
 

--- a/backend/src/main/kotlin/xyz/funkybit/core/services/UtxoManager.kt
+++ b/backend/src/main/kotlin/xyz/funkybit/core/services/UtxoManager.kt
@@ -44,7 +44,7 @@ object UtxoManager {
     }
 
     private fun refresh(walletAddress: BitcoinAddress, addressInfo: BitcoinUtxoAddressMonitorEntity): Long? {
-        logger.debug { "updating utxos for $walletAddress lastSeenBlockHeight=${addressInfo.lastSeenBlockHeight}" }
+        logger.info { "updating utxos for $walletAddress lastSeenBlockHeight=${addressInfo.lastSeenBlockHeight}" }
 
         // mempool pagination is a little odd
         // when the address/{addr}/txs endpoint for an address is called with no after-txid query param it will return
@@ -100,7 +100,7 @@ object UtxoManager {
         }
         spentUtxoMap.forEach { (txId, spentUtxos) ->
             if (spentUtxos.isNotEmpty()) {
-                logger.debug { "spending $spentUtxos by $txId" }
+                logger.info { "spending $spentUtxos by $txId" }
                 BitcoinUtxoEntity.spend(spentUtxos, txId)
             }
         }

--- a/backend/src/main/kotlin/xyz/funkybit/core/utils/HttpClient.kt
+++ b/backend/src/main/kotlin/xyz/funkybit/core/utils/HttpClient.kt
@@ -1,0 +1,60 @@
+package xyz.funkybit.core.utils
+
+import io.github.oshai.kotlinlogging.KLogger
+import okhttp3.MediaType
+import okhttp3.OkHttpClient
+import okhttp3.ResponseBody.Companion.toResponseBody
+import okio.Buffer
+
+private val defaultHttpClient = OkHttpClient.Builder().build()
+
+object HttpClient {
+    private val quietMode = ThreadLocal.withInitial { false }
+
+    fun setQuietModeForThread(value: Boolean) {
+        quietMode.set(value)
+    }
+
+    fun inQuietMode(): Boolean =
+        quietMode.get()
+
+    // It is recommended to use have a single HTTP client instance and share it
+    // across the application for better resource utilization
+    // newBuilder() method creates another instance that can be customized separately
+    // but would still use the same shared connection and thread pools internally
+    fun newBuilder(): OkHttpClient.Builder =
+        defaultHttpClient.newBuilder()
+}
+
+fun OkHttpClient.Builder.withLogging(logger: KLogger): OkHttpClient.Builder {
+    return addInterceptor { chain ->
+        if (HttpClient.inQuietMode()) {
+            return@addInterceptor chain.proceed(chain.request())
+        }
+
+        val request = chain.request()
+
+        // making a copy of request body since it can be consumed only once
+        val requestBodyCopy = request.newBuilder().build().body?.let { body ->
+            val requestBuffer = Buffer()
+            body.writeTo(requestBuffer)
+            requestBuffer.readUtf8()
+        } ?: ""
+
+        val response = chain.proceed(request)
+        val contentType: MediaType? = response.body?.contentType()
+        val responseBody = response.body?.string()
+
+        logger.debug { "HTTP call: url=${request.url}, request=${abbreviateString(requestBodyCopy)}, response code=${response.code}, response body=${responseBody?.let(::abbreviateString)}" }
+
+        response.newBuilder().body(responseBody?.toResponseBody(contentType)).build()
+    }
+}
+
+private fun abbreviateString(value: String): String {
+    return if (value.length < 4096) {
+        value
+    } else {
+        "${value.substring(0, 2048)} ... ${value.substring(value.length - 2048, value.length)}"
+    }
+}

--- a/backend/src/main/kotlin/xyz/funkybit/core/utils/Utils.kt
+++ b/backend/src/main/kotlin/xyz/funkybit/core/utils/Utils.kt
@@ -1,6 +1,5 @@
 package xyz.funkybit.core.utils
 
-import io.github.oshai.kotlinlogging.KLogger
 import kotlinx.datetime.DateTimeUnit
 import kotlinx.datetime.Instant
 import org.bouncycastle.util.encoders.Hex
@@ -13,14 +12,6 @@ import java.math.BigInteger
 import java.security.MessageDigest
 import java.security.SecureRandom
 import kotlin.time.Duration
-
-val quietMode = System.getenv("QUIET_MODE")?.toBoolean() ?: false
-
-fun KLogger.verboseInfo(message: () -> Any) {
-    if (!quietMode) {
-        this.info(message)
-    }
-}
 
 fun humanReadable(duration: Duration): String {
     return humanReadableNanoseconds((duration.inWholeNanoseconds))

--- a/integrationtests/src/main/kotlin/xyz/funkybit/integrationtests/utils/TestEvmClient.kt
+++ b/integrationtests/src/main/kotlin/xyz/funkybit/integrationtests/utils/TestEvmClient.kt
@@ -47,7 +47,7 @@ class TestEvmClient(evmConfig: EvmClientConfig) : EvmClient(evmConfig) {
         Request(
             "anvil_mine",
             listOf(numberOfBlocks),
-            web3jServiceNoLogging,
+            web3jService,
             VoidResponse::class.java,
         ).send()
     }

--- a/src/main/kotlin/xyz/funkybit/utils/BitcoinMiner.kt
+++ b/src/main/kotlin/xyz/funkybit/utils/BitcoinMiner.kt
@@ -3,6 +3,7 @@ package xyz.funkybit.utils
 import io.github.oshai.kotlinlogging.KotlinLogging
 import xyz.funkybit.core.blockchain.bitcoin.BitcoinClient
 import xyz.funkybit.core.blockchain.bitcoin.bitcoinConfig
+import xyz.funkybit.core.utils.HttpClient
 import kotlin.concurrent.thread
 
 object BitcoinMiner {
@@ -16,6 +17,8 @@ object BitcoinMiner {
         }
 
         miningThread = thread(start = true, name = "bitcoin mining", isDaemon = true) {
+            HttpClient.setQuietModeForThread(true)
+
             while (true) {
                 try {
                     BitcoinClient.mine(1)

--- a/src/main/resources/log4j2.xml
+++ b/src/main/resources/log4j2.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration packages="xyz.funkybit.core.utils" status="INFO">
+    <Properties>
+        <Property name="LOG_PATTERN">%d{yyyy-MM-dd HH:mm:ss} %-5p %c{1} TID:%tid, TN:"%tn" - %m%n</Property>
+    </Properties>
+
+    <Appenders>
+        <Console name="Console" target="SYSTEM_OUT">
+            <PatternLayout pattern="${LOG_PATTERN}"/>
+        </Console>
+        <Async name="AsyncAppender">
+            <AppenderRef ref="Console"/>
+        </Async>
+    </Appenders>
+    <Loggers>
+        <Logger name="xyz.funkybit" level="debug" additivity="false">
+            <AppenderRef ref="AsyncAppender"/>
+        </Logger>
+        <Root level="error">
+            <AppenderRef ref="AsyncAppender"/>
+        </Root>
+    </Loggers>
+</Configuration>


### PR DESCRIPTION
The idea is to use thread-local variable to silence HTTP client logs in busy background worker threads that are just polling data from the chain in a loop