### PR TITLE
Terraform dedicated log-groups with retention policy per env in AWS

### DIFF
--- a/terraform/modules/ecs_task/main.tf
+++ b/terraform/modules/ecs_task/main.tf
@@ -172,10 +172,9 @@ resource "aws_ecs_task_definition" "task" {
         logConfiguration = {
           logDriver = "awslogs"
           options = {
-            "awslogs-group" : "firelens-container",
+            "awslogs-group" : "ecs-logs-${var.name_prefix}",
             "awslogs-region" : var.aws_region,
-            "awslogs-create-group" : "true",
-            "awslogs-stream-prefix" : "${var.name_prefix}-${var.task_name}",
+            "awslogs-stream-prefix" : var.task_name,
             "mode" : "non-blocking"
           }
         }

--- a/terraform/shared/main.tf
+++ b/terraform/shared/main.tf
@@ -201,3 +201,23 @@ resource "aws_s3_bucket_policy" "bucket_policy" {
     ]
   })
 }
+
+resource "aws_cloudwatch_log_group" "test_log_group" {
+  name              = "ecs-logs-test"
+  retention_in_days = 7
+}
+
+resource "aws_cloudwatch_log_group" "demo_group" {
+  name              = "ecs-logs-demo"
+  retention_in_days = 7
+}
+
+resource "aws_cloudwatch_log_group" "testnet_group" {
+  name              = "ecs-logs-testnet"
+  retention_in_days = 14
+}
+
+resource "aws_cloudwatch_log_group" "prod_log_group" {
+  name              = "ecs-logs-prod"
+  retention_in_days = 14
+}


### PR DESCRIPTION
I've set `firelens-container` group's retention policy to 14 days by hand for now. Have already applied this in test env.