### PR TITLE
Optimize recent orders and trades fetching

### DIFF
--- a/backend/src/main/kotlin/xyz/funkybit/core/db/Migrations.kt
+++ b/backend/src/main/kotlin/xyz/funkybit/core/db/Migrations.kt
@@ -96,6 +96,7 @@ import xyz.funkybit.core.model.db.migrations.V94_UpdateArchAccountTable
 import xyz.funkybit.core.model.db.migrations.V95_AddIndexToBroadcasterJobTable
 import xyz.funkybit.core.model.db.migrations.V96_UpdateBitcoinUtxoTable
 import xyz.funkybit.core.model.db.migrations.V97_AddSentToArchStatusToDeposit
+import xyz.funkybit.core.model.db.migrations.V98_AddUserGuidToOrderAndExecution
 import xyz.funkybit.core.model.db.migrations.V9_SymbolTable
 
 val migrations = listOf(
@@ -196,4 +197,5 @@ val migrations = listOf(
     V95_AddIndexToBroadcasterJobTable(),
     V96_UpdateBitcoinUtxoTable(),
     V97_AddSentToArchStatusToDeposit(),
+    V98_AddUserGuidToOrderAndExecution(),
 )

--- a/backend/src/main/kotlin/xyz/funkybit/core/model/db/Order.kt
+++ b/backend/src/main/kotlin/xyz/funkybit/core/model/db/Order.kt
@@ -158,7 +158,7 @@ class OrderEntity(guid: EntityID<OrderId>) : GUIDEntity<OrderId>(guid) {
                         role = execution.role,
                         feeAmount = execution.feeAmount,
                         feeSymbol = execution.feeSymbol,
-                        marketId = execution.market?.guid?.value ?: this.marketGuid.value,
+                        marketId = execution.market.guid.value,
                     )
                 },
                 timing = Order.Timing(
@@ -186,7 +186,7 @@ class OrderEntity(guid: EntityID<OrderId>) : GUIDEntity<OrderId>(guid) {
                         role = execution.role,
                         feeAmount = execution.feeAmount,
                         feeSymbol = execution.feeSymbol,
-                        marketId = execution.market?.guid?.value ?: this.marketGuid.value,
+                        marketId = execution.market.guid.value,
                     )
                 },
                 timing = Order.Timing(

--- a/backend/src/main/kotlin/xyz/funkybit/core/model/db/migrations/V98_AddUserGuidToOrderAndExecution.kt
+++ b/backend/src/main/kotlin/xyz/funkybit/core/model/db/migrations/V98_AddUserGuidToOrderAndExecution.kt
@@ -27,6 +27,17 @@ class V98_AddUserGuidToOrderAndExecution : Migration() {
                 );
                 ALTER TABLE order_execution ADD CONSTRAINT fk_order_execution_user_guid__guid FOREIGN KEY (user_guid) REFERENCES "user"(guid);
                 ALTER TABLE order_execution ALTER COLUMN user_guid SET NOT NULL;
+                CREATE INDEX order_execution_user_guid_timestamp_index ON "order_execution" (user_guid, timestamp);
+                
+                ALTER TABLE order_execution ALTER COLUMN market_guid SET NOT NULL;
+                
+                ALTER TABLE order_execution ADD COLUMN response_sequence bigint;
+                UPDATE order_execution SET response_sequence = (
+                    SELECT response_sequence FROM trade WHERE trade.guid = order_execution.trade_guid
+                );
+                ALTER TABLE order_execution ALTER COLUMN response_sequence SET NOT NULL;
+                
+                CREATE INDEX order_execution_user_guid_response_sequence_index ON "order_execution" (user_guid, response_sequence);
                 """.trimIndent(),
             )
         }

--- a/backend/src/main/kotlin/xyz/funkybit/core/model/db/migrations/V98_AddUserGuidToOrderAndExecution.kt
+++ b/backend/src/main/kotlin/xyz/funkybit/core/model/db/migrations/V98_AddUserGuidToOrderAndExecution.kt
@@ -1,0 +1,34 @@
+package xyz.funkybit.core.model.db.migrations
+
+import org.jetbrains.exposed.sql.transactions.transaction
+import xyz.funkybit.core.db.Migration
+
+@Suppress("ClassName")
+class V98_AddUserGuidToOrderAndExecution : Migration() {
+    override fun run() {
+        transaction {
+            exec(
+                """
+                ALTER TABLE "order" ADD COLUMN user_guid CHARACTER VARYING(10485760);
+                UPDATE "order" SET user_guid = (
+                    SELECT user_guid FROM wallet WHERE wallet.guid = "order".wallet_guid
+                );
+                ALTER TABLE "order" ADD CONSTRAINT fk_order_user_guid__guid FOREIGN KEY (user_guid) REFERENCES "user"(guid);
+                ALTER TABLE "order" ALTER COLUMN user_guid SET NOT NULL;
+                CREATE INDEX order_user_guid_created_at_index ON "order" (user_guid, created_at);
+                """.trimIndent(),
+            )
+
+            exec(
+                """
+                ALTER TABLE order_execution ADD COLUMN user_guid CHARACTER VARYING(10485760);
+                UPDATE order_execution SET user_guid = (
+                    SELECT user_guid FROM "order" WHERE "order".guid = order_execution.order_guid
+                );
+                ALTER TABLE order_execution ADD CONSTRAINT fk_order_execution_user_guid__guid FOREIGN KEY (user_guid) REFERENCES "user"(guid);
+                ALTER TABLE order_execution ALTER COLUMN user_guid SET NOT NULL;
+                """.trimIndent(),
+            )
+        }
+    }
+}

--- a/backend/src/test/kotlin/xyz/funkybit/core/model/db/OrderExecutionEntityTest.kt
+++ b/backend/src/test/kotlin/xyz/funkybit/core/model/db/OrderExecutionEntityTest.kt
@@ -220,6 +220,7 @@ class OrderExecutionEntityTest : TestWithDb() {
                         feeSymbol = Symbol("ETH"),
                         marketEntity = order1.market,
                         side = order1.side,
+                        responseSequence = trade.responseSequence!!,
                     )
                     OrderExecutionEntity.create(
                         now,
@@ -235,6 +236,7 @@ class OrderExecutionEntityTest : TestWithDb() {
                         feeSymbol = Symbol("ETH"),
                         marketEntity = order1.market,
                         side = order2.side,
+                        responseSequence = trade.responseSequence!!,
                     )
                 }
             }

--- a/backend/src/test/kotlin/xyz/funkybit/core/model/db/OrderExecutionEntityTest.kt
+++ b/backend/src/test/kotlin/xyz/funkybit/core/model/db/OrderExecutionEntityTest.kt
@@ -34,25 +34,26 @@ class OrderExecutionEntityTest : TestWithDb() {
 
     @Test
     fun `list latest order executions for user`() {
-        val (makerWalletId, takerWalletId) = transaction { Pair(createWallet().id.value, createWallet().id.value) }
-        val makerWallet2Id = transaction {
+        val (makerWallet, takerWallet) = transaction { Pair(createWallet(), createWallet()) }
+
+        val makerWallet2 = transaction {
             createWallet(
                 address = BitcoinAddress.SegWit.generate(bitcoinConfig.params),
-                user = WalletEntity[makerWalletId].user,
-            ).id.value
+                user = makerWallet.user,
+            )
         }
 
         createOrders(
             listOf(
-                Order(OrderId("maker_order_1"), makerWalletId, btcEthMarket, OrderType.Limit, OrderSide.Sell),
-                Order(OrderId("maker_order_2"), makerWalletId, btcEthMarket, OrderType.Limit, OrderSide.Sell),
-                Order(OrderId("maker_order_3"), makerWalletId, btcEthMarket, OrderType.Limit, OrderSide.Sell),
-                Order(OrderId("maker_order_4"), makerWalletId, btcEthMarket, OrderType.Limit, OrderSide.Sell),
-                Order(OrderId("maker_order_5"), makerWalletId, btcEthMarket, OrderType.Limit, OrderSide.Sell),
-                Order(OrderId("maker_order_6"), makerWallet2Id, btcEthMarket, OrderType.Limit, OrderSide.Sell),
-                Order(OrderId("taker_order_1"), takerWalletId, btcEthMarket, OrderType.Market, OrderSide.Buy),
-                Order(OrderId("taker_order_2"), takerWalletId, btcEthMarket, OrderType.Market, OrderSide.Buy),
-                Order(OrderId("taker_order_3"), takerWalletId, btcEthMarket, OrderType.Market, OrderSide.Buy),
+                Order(OrderId("maker_order_1"), makerWallet, btcEthMarket, OrderType.Limit, OrderSide.Sell),
+                Order(OrderId("maker_order_2"), makerWallet, btcEthMarket, OrderType.Limit, OrderSide.Sell),
+                Order(OrderId("maker_order_3"), makerWallet, btcEthMarket, OrderType.Limit, OrderSide.Sell),
+                Order(OrderId("maker_order_4"), makerWallet, btcEthMarket, OrderType.Limit, OrderSide.Sell),
+                Order(OrderId("maker_order_5"), makerWallet, btcEthMarket, OrderType.Limit, OrderSide.Sell),
+                Order(OrderId("maker_order_6"), makerWallet2, btcEthMarket, OrderType.Limit, OrderSide.Sell),
+                Order(OrderId("taker_order_1"), takerWallet, btcEthMarket, OrderType.Market, OrderSide.Buy),
+                Order(OrderId("taker_order_2"), takerWallet, btcEthMarket, OrderType.Market, OrderSide.Buy),
+                Order(OrderId("taker_order_3"), takerWallet, btcEthMarket, OrderType.Market, OrderSide.Buy),
             ),
         )
 
@@ -60,7 +61,7 @@ class OrderExecutionEntityTest : TestWithDb() {
             assertEquals(
                 emptyList<Pair<TradeId, ExecutionRole>>(),
                 OrderExecutionEntity.listLatestForUser(
-                    WalletEntity[takerWalletId].userGuid,
+                    takerWallet.userGuid,
                     maxSequencerResponses = 10,
                 ).map { Pair(it.tradeGuid.value, it.role) },
             )
@@ -96,7 +97,7 @@ class OrderExecutionEntityTest : TestWithDb() {
                     Pair(TradeId("trade_taker_order_3_maker_order_6"), ExecutionRole.Taker),
                 ),
                 OrderExecutionEntity.listLatestForUser(
-                    WalletEntity[takerWalletId].userGuid,
+                    takerWallet.userGuid,
                     maxSequencerResponses = 1,
                 ).map { Pair(it.tradeGuid.value, it.role) },
             )
@@ -111,7 +112,7 @@ class OrderExecutionEntityTest : TestWithDb() {
                     Pair(TradeId("trade_taker_order_1_maker_order_2"), ExecutionRole.Taker),
                 ),
                 OrderExecutionEntity.listLatestForUser(
-                    WalletEntity[takerWalletId].userGuid,
+                    takerWallet.userGuid,
                     maxSequencerResponses = 2,
                 ).map { Pair(it.tradeGuid.value, it.role) },
             )
@@ -124,7 +125,7 @@ class OrderExecutionEntityTest : TestWithDb() {
                     Pair(TradeId("trade_taker_order_3_maker_order_6"), ExecutionRole.Maker),
                 ),
                 OrderExecutionEntity.listLatestForUser(
-                    WalletEntity[makerWalletId].userGuid,
+                    makerWallet.userGuid,
                     maxSequencerResponses = 1,
                 ).map { Pair(it.tradeGuid.value, it.role) },
             )
@@ -139,7 +140,7 @@ class OrderExecutionEntityTest : TestWithDb() {
                     Pair(TradeId("trade_taker_order_1_maker_order_2"), ExecutionRole.Maker),
                 ),
                 OrderExecutionEntity.listLatestForUser(
-                    WalletEntity[makerWalletId].userGuid,
+                    makerWallet.userGuid,
                     maxSequencerResponses = 2,
                 ).map { Pair(it.tradeGuid.value, it.role) },
             )
@@ -149,10 +150,14 @@ class OrderExecutionEntityTest : TestWithDb() {
     private data class Order(
         val id: OrderId,
         val wallet: WalletId,
+        val user: UserId,
         val market: MarketId,
         val type: OrderType,
         val side: OrderSide,
-    )
+    ) {
+        constructor(id: OrderId, wallet: WalletEntity, market: MarketId, type: OrderType, side: OrderSide) :
+            this(id, wallet.guid.value, wallet.userGuid.value, market, type, side)
+    }
 
     private data class SeqResponse(
         val sequence: Long,
@@ -168,6 +173,7 @@ class OrderExecutionEntityTest : TestWithDb() {
                     this.createdBy = ""
                     this.marketGuid = EntityID(it.market, MarketTable)
                     this.walletGuid = EntityID(it.wallet, WalletTable)
+                    this.userGuid = EntityID(it.user, UserTable)
                     this.status = OrderStatus.Filled
                     this.type = it.type
                     this.amount = BigInteger.ONE

--- a/backend/src/testFixtures/kotlin/xyz/funkybit/testfixtures/DbTestHelpers.kt
+++ b/backend/src/testFixtures/kotlin/xyz/funkybit/testfixtures/DbTestHelpers.kt
@@ -95,6 +95,7 @@ object DbTestHelpers {
             this.createdBy = "system"
             this.marketGuid = market.guid
             this.walletGuid = wallet.guid
+            this.userGuid = wallet.userGuid
             this.status = status
             this.side = side
             this.type = type

--- a/backend/src/testFixtures/kotlin/xyz/funkybit/testfixtures/OrderBookTestHelper.kt
+++ b/backend/src/testFixtures/kotlin/xyz/funkybit/testfixtures/OrderBookTestHelper.kt
@@ -97,6 +97,8 @@ object OrderBookTestHelper {
                             feeAmount = BigInteger.ZERO,
                             feeSymbol = Symbol(order.market.quoteSymbol.name),
                             side = order.side,
+                            marketEntity = tradeMarket,
+                            responseSequence = tradeEntity.responseSequence!!,
                         )
                     }
 

--- a/sequencer/src/main/kotlin/xyz/funkybit/sequencer/apps/services/SequencerResponseProcessorService.kt
+++ b/sequencer/src/main/kotlin/xyz/funkybit/sequencer/apps/services/SequencerResponseProcessorService.kt
@@ -317,6 +317,7 @@ object SequencerResponseProcessorService {
                         feeSymbol = Symbol(tradeMarket.quoteSymbol.name),
                         side = side,
                         marketEntity = tradeMarket,
+                        responseSequence = responseSequence,
                     )
 
                     execution.refresh(flush = true)


### PR DESCRIPTION
Order table in demo has around 70M records and fetching recent orders for market maker takes minutes affecting overall database performance quite badly.