### PR TITLE
Chain 407/api rate limiting

### DIFF
--- a/terraform/modules/waf/main.tf
+++ b/terraform/modules/waf/main.tf
@@ -19,6 +19,11 @@ resource "aws_wafv2_web_acl" "WafWebAcl" {
     sampled_requests_enabled   = true
   }
 
+  custom_response_body {
+    key          = "RateLimitExceededBody"
+    content      = jsonencode({ "message" : "Request rate limit exceeded. Please try again later." })
+    content_type = "APPLICATION_JSON"
+  }
 
   rule {
     name     = "${var.short_env_name}-AWSIPWhiteList"
@@ -113,7 +118,12 @@ resource "aws_wafv2_web_acl" "WafWebAcl" {
     priority = 5
 
     action {
-      block {}
+      block {
+        custom_response {
+          response_code            = var.ip_dos_rate_limit_response_code
+          custom_response_body_key = "RateLimitExceededBody" # Reference to the custom response body
+        }
+      }
     }
 
     statement {

--- a/terraform/modules/waf/variables.tf
+++ b/terraform/modules/waf/variables.tf
@@ -36,3 +36,7 @@ variable "blocked_country_response_code" {
 variable "ip_dos_rate_limit" {
   description = "How many requests per IP address."
 }
+
+variable "ip_dos_rate_limit_response_code" {
+  description = "Response code to return"
+}

--- a/terraform/testnet/.terraform.lock.hcl
+++ b/terraform/testnet/.terraform.lock.hcl
@@ -42,3 +42,22 @@ provider "registry.terraform.io/hashicorp/aws" {
     "zh:ebe60d3887b23703ca6a4c65b15c6d7b8d93ba27a028d996d17882fe6e98d5c0",
   ]
 }
+
+provider "registry.terraform.io/hashicorp/dns" {
+  version = "3.4.2"
+  hashes = [
+    "h1:fANvQG0D/XKyj+s+egm66efvr8z2gNKER6UlKfjUxvU=",
+    "zh:75e40862402368e23cd298b62519203621cf4891b95e1c863530bf7d8e9614e6",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:7a660fbfe5f83d7b94fd5b4cc9bf10d2f6ae280779839f4b7f183c7db5f1e368",
+    "zh:7c8c3499fb015d2a877a645ffd0225c3fdb4e8b71c044ff242762a1aed2a28e6",
+    "zh:954f20a96c8d6a04961896137bc004dae19fdaaaf8fd29229fb6ebc98ccac040",
+    "zh:96bd331cdd3673037e679b20cbf64e02e16f16f05a8c5dc2567c484fdd271d48",
+    "zh:96f83dfaeba393b1cf17feef05f25ffc4083432c1e3336a28977e626aac6eb53",
+    "zh:c663da6c3fda06a69d082d23935cebc34c7dc1b898e03a825b50628ad0e0ba71",
+    "zh:d0cc78a4f9444efe52764a57e7159b217181e0fd4ab4a610fa3bf7839bd94b02",
+    "zh:d1e938eec2c7ec946775bf984e79b3c66440fe3c08c3662bf0b40d3097985ed9",
+    "zh:dee0ccb0588f4c4224fe36e50f649ae36add82d72ccbf070800438860da820ac",
+    "zh:f2b3be35c8c97ed58f7d01ac532207fc816514eda639dcd3fd1929f5f5be369f",
+  ]
+}

--- a/terraform/testnet/main.tf
+++ b/terraform/testnet/main.tf
@@ -103,18 +103,18 @@ module "web" {
 }
 
 module "waf" {
-  source     = "../modules/waf"
-  aws_region = var.aws_region
-  aws_lb_arn = module.alb.lb_arn
-  #aws_lb_arn               = module.alb.https_listener_arn
-  short_env_name                = local.name_prefix
-  ipv4_blacklist_addresses      = local.ipv4blacklist
-  ipv4_whitelist_addresses      = local.ipv4whitelist
-  ipv6_blacklist_addresses      = local.ipv6blacklist
-  ipv6_whitelist_addresses      = local.ipv6whitelist
-  blocked_country_codes         = var.blocked_country_codes
-  blocked_country_response_code = var.blocked_country_response_code
-  ip_dos_rate_limit             = var.ip_dos_rate_limit
+  source                          = "../modules/waf"
+  aws_region                      = var.aws_region
+  aws_lb_arn                      = module.alb.lb_arn
+  short_env_name                  = local.name_prefix
+  ipv4_blacklist_addresses        = local.ipv4blacklist
+  ipv4_whitelist_addresses        = local.ipv4whitelist
+  ipv6_blacklist_addresses        = local.ipv6blacklist
+  ipv6_whitelist_addresses        = local.ipv6whitelist
+  blocked_country_codes           = var.blocked_country_codes
+  blocked_country_response_code   = var.blocked_country_response_code
+  ip_dos_rate_limit               = var.ip_dos_rate_limit
+  ip_dos_rate_limit_response_code = var.ip_dos_rate_limit_response_code
 }
 
 module "telegram_mini_app" {

--- a/terraform/testnet/variables.tf
+++ b/terraform/testnet/variables.tf
@@ -42,11 +42,15 @@ variable "blocked_country_codes" {
 }
 
 variable "blocked_country_response_code" {
-  default = 451
+  default = 451 # Unavailable For Legal Reasons
 }
 
 variable "ip_dos_rate_limit" {
   default = 5000
+}
+
+variable "ip_dos_rate_limit_response_code" {
+  default = 429 # Too many requests
 }
 
 

--- a/web-ui/src/apiClient.ts
+++ b/web-ui/src/apiClient.ts
@@ -1018,16 +1018,25 @@ export const noAuthApiClient = new Zodios(apiBaseUrl, [
   }
 ])
 
-export function useAccessRestriction() {
-  const [maintenance, setMaintenance] = useState(false)
-  const [restricted, setRestricted] = useState(false)
-  const [rateLimited, setRateLimited] = useState(false)
+export type AccessRestriction =
+  | 'none'
+  | 'underMaintenance'
+  | 'geoBlocked'
+  | 'requestLimitExceeded'
+export function useAccessRestriction(): AccessRestriction {
+  const [restriction, setRestriction] = useState<AccessRestriction>('none')
 
   useEffect(() => {
     const handleResponseCode = (status: number) => {
-      setMaintenance(status === 418)
-      setRestricted(status === 451)
-      setRateLimited(status === 429)
+      if (status === 418) {
+        setRestriction('underMaintenance')
+      } else if (status === 451) {
+        setRestriction('geoBlocked')
+      } else if (status === 429) {
+        setRestriction('requestLimitExceeded')
+      } else {
+        setRestriction('none')
+      }
     }
 
     const setupInterceptors = (client: { axios: AxiosInstance }) => {
@@ -1051,5 +1060,5 @@ export function useAccessRestriction() {
       apiClient.axios.interceptors.response.eject(id2)
     }
   }, [])
-  return [maintenance, restricted, rateLimited]
+  return restriction
 }

--- a/web-ui/src/index.tsx
+++ b/web-ui/src/index.tsx
@@ -15,7 +15,7 @@ const root = createRoot(container)
 const queryClient = new QueryClient()
 
 const Root = () => {
-  const [maintenance, restricted] = useAccessRestriction()
+  const [maintenance, restricted, rateLimited] = useAccessRestriction()
   const [, setIsConfigInitialized] = useState(false)
 
   useEffect(() => {
@@ -60,6 +60,13 @@ const Root = () => {
           <span className="animate-bounce">
             funkybit is currently undergoing maintenance, we&apos;ll be back
             soon.
+          </span>
+        </div>
+      )}
+      {rateLimited && (
+        <div className="fixed z-[100] flex w-full flex-row place-items-center justify-center bg-red p-0 text-white opacity-80">
+          <span className="animate-bounce">
+            You&apos;ve hit the rate limit! Please slow down and try again soon.
           </span>
         </div>
       )}

--- a/web-ui/src/index.tsx
+++ b/web-ui/src/index.tsx
@@ -15,7 +15,7 @@ const root = createRoot(container)
 const queryClient = new QueryClient()
 
 const Root = () => {
-  const [maintenance, restricted, rateLimited] = useAccessRestriction()
+  const accessRestriction = useAccessRestriction()
   const [, setIsConfigInitialized] = useState(false)
 
   useEffect(() => {
@@ -35,7 +35,7 @@ const Root = () => {
     initConfig()
   }, [])
 
-  if (restricted) {
+  if (accessRestriction == 'geoBlocked') {
     return (
       <div className="flex h-screen items-center justify-center bg-darkBluishGray10 text-white">
         <div className="w-2/3 text-center ">
@@ -55,7 +55,7 @@ const Root = () => {
 
   return (
     <>
-      {maintenance && (
+      {accessRestriction == 'underMaintenance' && (
         <div className="fixed z-[100] flex w-full flex-row place-items-center justify-center bg-red p-0 text-white opacity-80">
           <span className="animate-bounce">
             funkybit is currently undergoing maintenance, we&apos;ll be back
@@ -63,7 +63,7 @@ const Root = () => {
           </span>
         </div>
       )}
-      {rateLimited && (
+      {accessRestriction == 'requestLimitExceeded' && (
         <div className="fixed z-[100] flex w-full flex-row place-items-center justify-center bg-red p-0 text-white opacity-80">
           <span className="animate-bounce">
             You&apos;ve hit the rate limit! Please slow down and try again soon.


### PR DESCRIPTION
* friendly WAF response (429 -> `{"message":"Request rate limit exceeded. Please try again later."}`)
* UI message in the same style as maintenance
* interceptor that processed response code is also added to `noAuthApiClient` that is used to fetch configuration to make sure maintenance mode is recognized on page reload

===
<img width="614" alt="Screenshot 2024-10-14 at 2 28 32 PM" src="https://github.com/user-attachments/assets/81c02080-60c8-455f-8cbc-90bdce3480ce">
