### PR TITLE
Improve order batch handling

### DIFF
--- a/backend/src/main/kotlin/xyz/funkybit/apps/api/model/Errors.kt
+++ b/backend/src/main/kotlin/xyz/funkybit/apps/api/model/Errors.kt
@@ -25,6 +25,7 @@ enum class ReasonCode {
     WithdrawalNotFound,
     DepositNotFound,
     MarketNotFound,
+    BatchSizeExceeded,
 
     SignatureNotValid,
     UnexpectedError,

--- a/backend/src/main/kotlin/xyz/funkybit/apps/api/model/websocket/OutgoingWSMessage.kt
+++ b/backend/src/main/kotlin/xyz/funkybit/apps/api/model/websocket/OutgoingWSMessage.kt
@@ -249,15 +249,15 @@ data class Balances(
 ) : Publishable()
 
 @Serializable
-@SerialName("MyOrderCreated")
-data class MyOrderCreated(
-    val order: Order,
+@SerialName("MyOrdersCreated")
+data class MyOrdersCreated(
+    val orders: List<Order>,
 ) : Publishable()
 
 @Serializable
-@SerialName("MyOrderUpdated")
-data class MyOrderUpdated(
-    val order: Order,
+@SerialName("MyOrdersUpdated")
+data class MyOrdersUpdated(
+    val orders: List<Order>,
 ) : Publishable()
 
 @Serializable

--- a/backend/src/main/kotlin/xyz/funkybit/core/db/Migrations.kt
+++ b/backend/src/main/kotlin/xyz/funkybit/core/db/Migrations.kt
@@ -1,6 +1,7 @@
 package xyz.funkybit.core.db
 
 import xyz.funkybit.core.model.db.migrations.V100_AddDiscordUserIdToUser
+import xyz.funkybit.core.model.db.migrations.V101_OHLCTimestampWithTimezone
 import xyz.funkybit.core.model.db.migrations.V10_WithdrawalTable
 import xyz.funkybit.core.model.db.migrations.V11_NonNullableDeployedContractProxyAddress
 import xyz.funkybit.core.model.db.migrations.V12_BigDecimalPrice
@@ -202,4 +203,5 @@ val migrations = listOf(
     V98_AddUserGuidToOrderAndExecution(),
     V99_AddArchRollbackTransactionToWithdrawal(),
     V100_AddDiscordUserIdToUser(),
+    V101_OHLCTimestampWithTimezone(),
 )

--- a/backend/src/main/kotlin/xyz/funkybit/core/model/db/OHLC.kt
+++ b/backend/src/main/kotlin/xyz/funkybit/core/model/db/OHLC.kt
@@ -1,39 +1,30 @@
 package xyz.funkybit.core.model.db
 
 import de.fxlae.typeid.TypeId
-import kotlinx.datetime.Clock
 import kotlinx.datetime.DateTimeUnit
 import kotlinx.datetime.Instant
 import kotlinx.serialization.Serializable
 import org.jetbrains.exposed.dao.EntityClass
+import org.jetbrains.exposed.dao.entityCache
 import org.jetbrains.exposed.dao.id.EntityID
-import org.jetbrains.exposed.sql.Case
+import org.jetbrains.exposed.sql.ResultRow
 import org.jetbrains.exposed.sql.SortOrder
-import org.jetbrains.exposed.sql.SqlExpressionBuilder.greater
-import org.jetbrains.exposed.sql.SqlExpressionBuilder.less
-import org.jetbrains.exposed.sql.SqlExpressionBuilder.lessEq
-import org.jetbrains.exposed.sql.SqlExpressionBuilder.plus
 import org.jetbrains.exposed.sql.and
-import org.jetbrains.exposed.sql.decimalLiteral
 import org.jetbrains.exposed.sql.kotlin.datetime.timestamp
-import org.jetbrains.exposed.sql.kotlin.datetime.timestampLiteral
-import org.jetbrains.exposed.sql.statements.UpsertStatement
-import org.jetbrains.exposed.sql.upsert
+import org.jetbrains.exposed.sql.statements.StatementType
+import org.jetbrains.exposed.sql.transactions.TransactionManager
 import xyz.funkybit.apps.api.model.websocket.OHLC
 import xyz.funkybit.core.model.db.OHLCTable.close
-import xyz.funkybit.core.model.db.OHLCTable.duration
 import xyz.funkybit.core.model.db.OHLCTable.firstTrade
 import xyz.funkybit.core.model.db.OHLCTable.high
 import xyz.funkybit.core.model.db.OHLCTable.lastTrade
 import xyz.funkybit.core.model.db.OHLCTable.low
-import xyz.funkybit.core.model.db.OHLCTable.marketGuid
 import xyz.funkybit.core.model.db.OHLCTable.open
-import xyz.funkybit.core.model.db.OHLCTable.start
-import xyz.funkybit.core.model.db.OHLCTable.updatedAt
 import xyz.funkybit.core.model.db.OHLCTable.volume
 import xyz.funkybit.core.utils.truncateTo
 import java.math.BigDecimal
 import java.math.BigInteger
+import java.sql.ResultSet
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.days
 import kotlin.time.Duration.Companion.hours
@@ -124,52 +115,53 @@ class OHLCEntity(guid: EntityID<OHLCId>) : GUIDEntity<OHLCId>(guid) {
     companion object : EntityClass<OHLCId, OHLCEntity>(OHLCTable) {
 
         fun updateWith(market: MarketId, tradeTimestamp: Instant, tradePrice: BigDecimal, tradeAmount: BigInteger): List<OHLCEntity> {
-            return OHLCDuration.entries.map { ohlcDuration ->
-                ohlcDuration to ohlcDuration.durationStart(tradeTimestamp)
-            }.map { (ohlcDuration, ohlcStart) ->
-                OHLCTable.upsert(
-                    keys = arrayOf(marketGuid, start, duration),
-                    onUpdate = mutableListOf(
-                        open to Case().When(firstTrade.greater(tradeTimestamp), decimalLiteral(tradePrice)).Else(open),
-                        high to Case().When(high.less(tradePrice), decimalLiteral(tradePrice)).Else(high),
-                        low to Case().When(low.greater(tradePrice), decimalLiteral(tradePrice)).Else(low),
-                        close to Case().When(lastTrade.lessEq(tradeTimestamp), decimalLiteral(tradePrice)).Else(close),
-                        volume to volume.plus(decimalLiteral(tradeAmount.toBigDecimal())),
-                        firstTrade to Case().When(firstTrade.greater(tradeTimestamp), timestampLiteral(tradeTimestamp)).Else(firstTrade),
-                        lastTrade to Case().When(lastTrade.lessEq(tradeTimestamp), timestampLiteral(tradeTimestamp)).Else(lastTrade),
-                        updatedAt to timestampLiteral(Clock.System.now()),
-                    ),
-                    body = fun OHLCTable.(it: UpsertStatement<Long>) {
-                        it[id] = OHLCId.generate()
-                        it[marketGuid] = market
-                        it[start] = ohlcStart
-                        it[duration] = ohlcDuration
-                        it[open] = tradePrice
-                        it[high] = tradePrice
-                        it[low] = tradePrice
-                        it[close] = tradePrice
-                        it[volume] = tradeAmount.toBigDecimal()
-                        it[firstTrade] = tradeTimestamp
-                        it[lastTrade] = tradeTimestamp
-                        it[createdAt] = Clock.System.now()
-                    },
-                )
-                (ohlcDuration to ohlcStart)
-            }.mapNotNull { (ohlcDuration, ohlcStart) ->
-                findSingleByExactStartTime(market, ohlcDuration, ohlcStart)
-            }
+            return TransactionManager.current().exec(
+                """
+                    INSERT INTO ${OHLCTable.tableName} (guid, market_guid, start, duration, open, high, low, close, amount, first_trade, last_trade, created_at)
+                    VALUES ${
+                    OHLCDuration.entries.joinToString(",") { ohlcDuration ->
+                        "('${OHLCId.generate()}', '$market', '${ohlcDuration.durationStart(tradeTimestamp)}', '$ohlcDuration'::ohlcduration, $tradePrice, $tradePrice, $tradePrice, $tradePrice, ${tradeAmount.toBigDecimal()}, '$tradeTimestamp', '$tradeTimestamp', now())"
+                    }
+                }
+                    ON CONFLICT (market_guid, start, duration) DO UPDATE
+                    SET
+                        open = CASE WHEN ${OHLCTable.tableName}.${firstTrade.name} > EXCLUDED.first_trade THEN EXCLUDED.open ELSE ${OHLCTable.tableName}.${open.name} END,
+                        high = CASE WHEN ${OHLCTable.tableName}.${high.name} < EXCLUDED.high THEN EXCLUDED.high ELSE ${OHLCTable.tableName}.${high.name} END,
+                        low = CASE WHEN ${OHLCTable.tableName}.${low.name} > EXCLUDED.low THEN EXCLUDED.low ELSE ${OHLCTable.tableName}.${low.name} END,
+                        close = CASE WHEN ${OHLCTable.tableName}.${lastTrade.name} <= EXCLUDED.last_trade THEN EXCLUDED.close ELSE ${OHLCTable.tableName}.${close.name} END,
+                        amount = ${OHLCTable.tableName}.${volume.name} + EXCLUDED.amount,
+                        first_trade = CASE WHEN ${OHLCTable.tableName}.${firstTrade.name} > EXCLUDED.first_trade THEN EXCLUDED.first_trade ELSE ${OHLCTable.tableName}.${firstTrade.name} END,
+                        last_trade = CASE WHEN ${OHLCTable.tableName}.${lastTrade.name} <= EXCLUDED.last_trade THEN EXCLUDED.last_trade ELSE ${OHLCTable.tableName}.${lastTrade.name} END,
+                        updated_at = now()
+                   RETURNING ${OHLCTable.columns.joinToString(", ") { it.name }}
+                """,
+                explicitStatementType = StatementType.SELECT,
+            ) { rs: ResultSet ->
+                val entityCache = TransactionManager.current().entityCache
+                val fieldsIndex = OHLCTable.fields.withIndex().associate { (index, field) -> field to index }
+
+                generateSequence {
+                    if (rs.next()) {
+                        // remove entity from cache to make sure updated OHLC record is actually read from the result set
+                        val entityId = EntityID(OHLCId(rs.getString(1)), OHLCTable)
+                        entityCache.find(OHLCEntity, entityId)?.let {
+                            entityCache.remove(OHLCTable, it)
+                        }
+
+                        // read updated OHLC record
+                        val resultRow = ResultRow.create(rs, fieldsIndex)
+                        OHLCEntity.wrapRow(resultRow)
+                    } else {
+                        null
+                    }
+                }.toList()
+            } ?: emptyList()
         }
 
         fun fetchForMarketStartingFrom(market: MarketId, duration: OHLCDuration, startTime: Instant): List<OHLCEntity> {
             return OHLCEntity.find {
                 OHLCTable.marketGuid.eq(market) and OHLCTable.duration.eq(duration) and OHLCTable.start.greaterEq(startTime)
             }.orderBy(OHLCTable.start to SortOrder.ASC).toList()
-        }
-
-        private fun findSingleByExactStartTime(market: MarketId, duration: OHLCDuration, startTime: Instant): OHLCEntity? {
-            return OHLCEntity.find {
-                OHLCTable.marketGuid.eq(market) and OHLCTable.duration.eq(duration) and OHLCTable.start.eq(startTime)
-            }.orderBy(OHLCTable.start to SortOrder.ASC).singleOrNull()
         }
 
         fun findSingleByClosestStartTime(market: MarketId, duration: OHLCDuration, startTime: Instant): OHLCEntity? {

--- a/backend/src/main/kotlin/xyz/funkybit/core/model/db/OHLC.kt
+++ b/backend/src/main/kotlin/xyz/funkybit/core/model/db/OHLC.kt
@@ -117,21 +117,23 @@ class OHLCEntity(guid: EntityID<OHLCId>) : GUIDEntity<OHLCId>(guid) {
         fun updateWith(market: MarketId, tradeTimestamp: Instant, tradePrice: BigDecimal, tradeAmount: BigInteger): List<OHLCEntity> {
             return TransactionManager.current().exec(
                 """
-                    INSERT INTO ${OHLCTable.tableName} (guid, market_guid, start, duration, open, high, low, close, amount, first_trade, last_trade, created_at)
+                    INSERT INTO ${OHLCTable.tableName} (${OHLCTable.guid.name}, ${OHLCTable.marketGuid.name}, ${OHLCTable.start.name}, ${OHLCTable.duration.name}, 
+                        ${OHLCTable.open.name}, ${OHLCTable.high.name}, ${OHLCTable.low.name}, ${OHLCTable.close.name}, ${OHLCTable.volume.name}, 
+                        ${OHLCTable.firstTrade.name}, ${OHLCTable.lastTrade.name}, ${OHLCTable.createdAt.name})
                     VALUES ${
                     OHLCDuration.entries.joinToString(",") { ohlcDuration ->
                         "('${OHLCId.generate()}', '$market', '${ohlcDuration.durationStart(tradeTimestamp)}', '$ohlcDuration'::ohlcduration, $tradePrice, $tradePrice, $tradePrice, $tradePrice, ${tradeAmount.toBigDecimal()}, '$tradeTimestamp', '$tradeTimestamp', now())"
                     }
                 }
-                    ON CONFLICT (market_guid, start, duration) DO UPDATE
+                    ON CONFLICT (${OHLCTable.marketGuid.name}, ${OHLCTable.start.name}, ${OHLCTable.duration.name}) DO UPDATE
                     SET
-                        open = CASE WHEN ${OHLCTable.tableName}.${firstTrade.name} > EXCLUDED.first_trade THEN EXCLUDED.open ELSE ${OHLCTable.tableName}.${open.name} END,
-                        high = CASE WHEN ${OHLCTable.tableName}.${high.name} < EXCLUDED.high THEN EXCLUDED.high ELSE ${OHLCTable.tableName}.${high.name} END,
-                        low = CASE WHEN ${OHLCTable.tableName}.${low.name} > EXCLUDED.low THEN EXCLUDED.low ELSE ${OHLCTable.tableName}.${low.name} END,
-                        close = CASE WHEN ${OHLCTable.tableName}.${lastTrade.name} <= EXCLUDED.last_trade THEN EXCLUDED.close ELSE ${OHLCTable.tableName}.${close.name} END,
-                        amount = ${OHLCTable.tableName}.${volume.name} + EXCLUDED.amount,
-                        first_trade = CASE WHEN ${OHLCTable.tableName}.${firstTrade.name} > EXCLUDED.first_trade THEN EXCLUDED.first_trade ELSE ${OHLCTable.tableName}.${firstTrade.name} END,
-                        last_trade = CASE WHEN ${OHLCTable.tableName}.${lastTrade.name} <= EXCLUDED.last_trade THEN EXCLUDED.last_trade ELSE ${OHLCTable.tableName}.${lastTrade.name} END,
+                        open = CASE WHEN ${OHLCTable.tableName}.${firstTrade.name} > EXCLUDED.${firstTrade.name} THEN EXCLUDED.${open.name} ELSE ${OHLCTable.tableName}.${open.name} END,
+                        high = CASE WHEN ${OHLCTable.tableName}.${high.name} < EXCLUDED.${high.name} THEN EXCLUDED.${high.name} ELSE ${OHLCTable.tableName}.${high.name} END,
+                        low = CASE WHEN ${OHLCTable.tableName}.${low.name} > EXCLUDED.${low.name} THEN EXCLUDED.${low.name} ELSE ${OHLCTable.tableName}.${low.name} END,
+                        close = CASE WHEN ${OHLCTable.tableName}.${lastTrade.name} <= EXCLUDED.${lastTrade.name} THEN EXCLUDED.${close.name} ELSE ${OHLCTable.tableName}.${close.name} END,
+                        amount = ${OHLCTable.tableName}.${volume.name} + EXCLUDED.${volume.name},
+                        first_trade = CASE WHEN ${OHLCTable.tableName}.${firstTrade.name} > EXCLUDED.${firstTrade.name} THEN EXCLUDED.${firstTrade.name} ELSE ${OHLCTable.tableName}.${firstTrade.name} END,
+                        last_trade = CASE WHEN ${OHLCTable.tableName}.${lastTrade.name} <= EXCLUDED.${lastTrade.name} THEN EXCLUDED.${lastTrade.name} ELSE ${OHLCTable.tableName}.${lastTrade.name} END,
                         updated_at = now()
                    RETURNING ${OHLCTable.columns.joinToString(", ") { it.name }}
                 """,

--- a/backend/src/main/kotlin/xyz/funkybit/core/model/db/OHLC.kt
+++ b/backend/src/main/kotlin/xyz/funkybit/core/model/db/OHLC.kt
@@ -135,6 +135,7 @@ class OHLCEntity(guid: EntityID<OHLCId>) : GUIDEntity<OHLCId>(guid) {
                         updated_at = now()
                    RETURNING ${OHLCTable.columns.joinToString(", ") { it.name }}
                 """,
+                // instruct exposed to expect result set
                 explicitStatementType = StatementType.SELECT,
             ) { rs: ResultSet ->
                 val entityCache = TransactionManager.current().entityCache
@@ -142,15 +143,14 @@ class OHLCEntity(guid: EntityID<OHLCId>) : GUIDEntity<OHLCId>(guid) {
 
                 generateSequence {
                     if (rs.next()) {
-                        // remove entity from cache to make sure updated OHLC record is actually read from the result set
+                        // remove entities from the entity cache to make sure updated OHLC record is actually read from the result set
                         val entityId = EntityID(OHLCId(rs.getString(1)), OHLCTable)
                         entityCache.find(OHLCEntity, entityId)?.let {
                             entityCache.remove(OHLCTable, it)
                         }
 
-                        // read updated OHLC record
-                        val resultRow = ResultRow.create(rs, fieldsIndex)
-                        OHLCEntity.wrapRow(resultRow)
+                        // read the updated OHLC record
+                        OHLCEntity.wrapRow(ResultRow.create(rs, fieldsIndex))
                     } else {
                         null
                     }

--- a/backend/src/main/kotlin/xyz/funkybit/core/model/db/migrations/V101_OHLCTimestampWithTimezone.kt
+++ b/backend/src/main/kotlin/xyz/funkybit/core/model/db/migrations/V101_OHLCTimestampWithTimezone.kt
@@ -1,0 +1,18 @@
+package xyz.funkybit.core.model.db.migrations
+
+import org.jetbrains.exposed.sql.transactions.transaction
+import xyz.funkybit.core.db.Migration
+
+@Suppress("ClassName")
+class V101_OHLCTimestampWithTimezone : Migration() {
+
+    override fun run() {
+        transaction {
+            exec("ALTER TABLE ohlc ALTER COLUMN start TYPE timestamp with time zone using start::timestamp with time zone")
+            exec("ALTER TABLE ohlc ALTER COLUMN first_trade TYPE timestamp with time zone using first_trade::timestamp with time zone")
+            exec("ALTER TABLE ohlc ALTER COLUMN last_trade TYPE timestamp with time zone using last_trade::timestamp with time zone")
+            exec("ALTER TABLE ohlc ALTER COLUMN created_at TYPE timestamp with time zone using created_at::timestamp with time zone")
+            exec("ALTER TABLE ohlc ALTER COLUMN updated_at TYPE timestamp with time zone using updated_at::timestamp with time zone")
+        }
+    }
+}

--- a/backend/src/main/kotlin/xyz/funkybit/core/websocket/Broadcaster.kt
+++ b/backend/src/main/kotlin/xyz/funkybit/core/websocket/Broadcaster.kt
@@ -12,9 +12,9 @@ import org.jetbrains.exposed.sql.transactions.transaction
 import xyz.funkybit.apps.api.model.websocket.Balances
 import xyz.funkybit.apps.api.model.websocket.Limits
 import xyz.funkybit.apps.api.model.websocket.MarketTradesCreated
-import xyz.funkybit.apps.api.model.websocket.MyOrderCreated
-import xyz.funkybit.apps.api.model.websocket.MyOrderUpdated
 import xyz.funkybit.apps.api.model.websocket.MyOrders
+import xyz.funkybit.apps.api.model.websocket.MyOrdersCreated
+import xyz.funkybit.apps.api.model.websocket.MyOrdersUpdated
 import xyz.funkybit.apps.api.model.websocket.MyTrades
 import xyz.funkybit.apps.api.model.websocket.MyTradesCreated
 import xyz.funkybit.apps.api.model.websocket.MyTradesUpdated
@@ -337,7 +337,7 @@ class Broadcaster(val db: Database) {
                 SubscriptionTopic.OrderBook(notification.message.marketId)
             }
             is OrderBookDiff -> SubscriptionTopic.IncrementalOrderBook(notification.message.marketId)
-            is MyOrders, is MyOrderCreated, is MyOrderUpdated -> SubscriptionTopic.MyOrders
+            is MyOrders, is MyOrdersCreated, is MyOrdersUpdated -> SubscriptionTopic.MyOrders
             is Prices -> {
                 updatePrices(notification.message)
                 SubscriptionTopic.Prices(notification.message.market, notification.message.duration)

--- a/integrationtests/src/test/kotlin/xyz/funkybit/integrationtests/api/AuthorizeWalletTest.kt
+++ b/integrationtests/src/test/kotlin/xyz/funkybit/integrationtests/api/AuthorizeWalletTest.kt
@@ -27,10 +27,10 @@ import xyz.funkybit.integrationtests.utils.WalletKeyPair
 import xyz.funkybit.integrationtests.utils.assertAmount
 import xyz.funkybit.integrationtests.utils.assertBalancesMessageReceived
 import xyz.funkybit.integrationtests.utils.assertError
-import xyz.funkybit.integrationtests.utils.assertMyLimitOrderCreatedMessageReceived
-import xyz.funkybit.integrationtests.utils.assertMyMarketOrderCreatedMessageReceived
-import xyz.funkybit.integrationtests.utils.assertMyOrderUpdatedMessageReceived
+import xyz.funkybit.integrationtests.utils.assertMyLimitOrdersCreatedMessageReceived
+import xyz.funkybit.integrationtests.utils.assertMyMarketOrdersCreatedMessageReceived
 import xyz.funkybit.integrationtests.utils.assertMyOrdersMessageReceived
+import xyz.funkybit.integrationtests.utils.assertMyOrdersUpdatedMessageReceived
 import xyz.funkybit.integrationtests.utils.assertMyTradesCreatedMessageReceived
 import xyz.funkybit.integrationtests.utils.assertMyTradesMessageReceived
 import xyz.funkybit.integrationtests.utils.assertMyTradesUpdatedMessageReceived
@@ -270,7 +270,7 @@ class AuthorizeWalletTest : OrderBaseTest() {
 
         val limitBuyOrderApiResponse = apiClient.createLimitOrder(market, OrderSide.Sell, amount, price, wallet)
 
-        wsClient.assertMyLimitOrderCreatedMessageReceived(limitBuyOrderApiResponse)
+        wsClient.assertMyLimitOrdersCreatedMessageReceived(limitBuyOrderApiResponse)
         wsClient.close()
     }
 
@@ -293,9 +293,9 @@ class AuthorizeWalletTest : OrderBaseTest() {
         val marketBuyOrderApiResponse = apiClient.createMarketOrder(market, OrderSide.Buy, btcBuyAmount, wallet)
 
         wsClient.apply {
-            assertMyMarketOrderCreatedMessageReceived(marketBuyOrderApiResponse)
+            assertMyMarketOrdersCreatedMessageReceived(marketBuyOrderApiResponse)
             assertMyTradesCreatedMessageReceived {}
-            assertMyOrderUpdatedMessageReceived {}
+            assertMyOrdersUpdatedMessageReceived {}
             assertBalancesMessageReceived {}
         }
 

--- a/integrationtests/src/test/kotlin/xyz/funkybit/integrationtests/api/BackToBackOrderTest.kt
+++ b/integrationtests/src/test/kotlin/xyz/funkybit/integrationtests/api/BackToBackOrderTest.kt
@@ -21,8 +21,8 @@ import xyz.funkybit.integrationtests.utils.ExpectedBalance
 import xyz.funkybit.integrationtests.utils.assertBalances
 import xyz.funkybit.integrationtests.utils.assertBalancesMessageReceived
 import xyz.funkybit.integrationtests.utils.assertLimitsMessageReceived
-import xyz.funkybit.integrationtests.utils.assertMyOrderCreatedMessageReceived
-import xyz.funkybit.integrationtests.utils.assertMyOrderUpdatedMessageReceived
+import xyz.funkybit.integrationtests.utils.assertMyOrdersCreatedMessageReceived
+import xyz.funkybit.integrationtests.utils.assertMyOrdersUpdatedMessageReceived
 import xyz.funkybit.integrationtests.utils.assertMyTradesCreatedMessageReceived
 import xyz.funkybit.integrationtests.utils.ofAsset
 import xyz.funkybit.sequencer.core.notional
@@ -115,7 +115,7 @@ class BackToBackOrderTest : OrderBaseTest() {
         assertEquals(1, limitBuyOrder2.createdOrders.count { it.requestStatus == RequestStatus.Accepted })
 
         repeat(2) {
-            makerWsClient.assertMyOrderCreatedMessageReceived()
+            makerWsClient.assertMyOrdersCreatedMessageReceived()
             makerWsClient.assertLimitsMessageReceived()
         }
 
@@ -130,7 +130,7 @@ class BackToBackOrderTest : OrderBaseTest() {
         )
 
         takerWsClient.apply {
-            assertMyOrderCreatedMessageReceived()
+            assertMyOrdersCreatedMessageReceived()
             assertMyTradesCreatedMessageReceived {
                 assertEquals(2, it.trades.size)
 
@@ -148,9 +148,12 @@ class BackToBackOrderTest : OrderBaseTest() {
                 assertEquals(BigInteger.ZERO, it.trades[1].feeAmount)
                 assertEquals(eth2.name, it.trades[1].feeSymbol.value)
             }
-            assertMyOrderUpdatedMessageReceived {
-                assertEquals(BigDecimal("0.6").toFundamentalUnits(market.baseDecimals), it.order.amount)
-                assertEquals(it.order.status, OrderStatus.Filled)
+            assertMyOrdersUpdatedMessageReceived { msg ->
+                assertEquals(1, msg.orders.size)
+                msg.orders.first().let { order ->
+                    assertEquals(BigDecimal("0.6").toFundamentalUnits(market.baseDecimals), order.amount)
+                    assertEquals(order.status, OrderStatus.Filled)
+                }
             }
             assertBalancesMessageReceived(
                 listOf(
@@ -165,7 +168,9 @@ class BackToBackOrderTest : OrderBaseTest() {
             assertMyTradesCreatedMessageReceived {
                 assertEquals(2, it.trades.size)
             }
-            repeat(2) { assertMyOrderUpdatedMessageReceived() }
+            assertMyOrdersUpdatedMessageReceived {
+                assertEquals(2, it.orders.size)
+            }
             assertBalancesMessageReceived()
             assertLimitsMessageReceived()
         }
@@ -301,7 +306,7 @@ class BackToBackOrderTest : OrderBaseTest() {
         assertEquals(1, limitBuyOrder2.createdOrders.count { it.requestStatus == RequestStatus.Accepted })
 
         repeat(2) {
-            makerWsClient.assertMyOrderCreatedMessageReceived()
+            makerWsClient.assertMyOrdersCreatedMessageReceived()
             makerWsClient.assertLimitsMessageReceived()
         }
 
@@ -316,7 +321,7 @@ class BackToBackOrderTest : OrderBaseTest() {
         )
 
         takerWsClient.apply {
-            assertMyOrderCreatedMessageReceived()
+            assertMyOrdersCreatedMessageReceived()
             assertMyTradesCreatedMessageReceived {
                 assertEquals(2, it.trades.size)
 
@@ -333,9 +338,12 @@ class BackToBackOrderTest : OrderBaseTest() {
                 assertEquals(BigInteger.ZERO, it.trades[1].feeAmount)
                 assertEquals(usdc2.name, it.trades[1].feeSymbol.value)
             }
-            assertMyOrderUpdatedMessageReceived {
-                assertEquals(BigDecimal("3.9").toFundamentalUnits(market.baseDecimals), it.order.amount)
-                assertEquals(it.order.status, OrderStatus.Partial)
+            assertMyOrdersUpdatedMessageReceived { msg ->
+                assertEquals(1, msg.orders.size)
+                msg.orders.first().let { order ->
+                    assertEquals(BigDecimal("3.9").toFundamentalUnits(market.baseDecimals), order.amount)
+                    assertEquals(order.status, OrderStatus.Partial)
+                }
             }
             assertBalancesMessageReceived(
                 listOf(
@@ -350,7 +358,9 @@ class BackToBackOrderTest : OrderBaseTest() {
             assertMyTradesCreatedMessageReceived {
                 assertEquals(2, it.trades.size)
             }
-            repeat(2) { assertMyOrderUpdatedMessageReceived() }
+            assertMyOrdersUpdatedMessageReceived {
+                assertEquals(2, it.orders.size)
+            }
             assertBalancesMessageReceived()
             assertLimitsMessageReceived()
         }
@@ -491,7 +501,7 @@ class BackToBackOrderTest : OrderBaseTest() {
         assertEquals(1, limitSellOrder.createdOrders.count { it.requestStatus == RequestStatus.Accepted })
 
         repeat(2) {
-            makerWsClient.assertMyOrderCreatedMessageReceived()
+            makerWsClient.assertMyOrdersCreatedMessageReceived()
             makerWsClient.assertLimitsMessageReceived()
         }
 
@@ -505,7 +515,7 @@ class BackToBackOrderTest : OrderBaseTest() {
         )
 
         takerWsClient.apply {
-            assertMyOrderCreatedMessageReceived()
+            assertMyOrdersCreatedMessageReceived()
             assertMyTradesCreatedMessageReceived {
                 assertEquals(2, it.trades.size)
 
@@ -524,9 +534,12 @@ class BackToBackOrderTest : OrderBaseTest() {
                 assertEquals(BigInteger.valueOf(4), it.trades[1].feeAmount)
                 assertEquals(eth2.name, it.trades[1].feeSymbol.value)
             }
-            assertMyOrderUpdatedMessageReceived {
-                assertEquals(inputOrderAmount.inFundamentalUnits, it.order.amount)
-                assertEquals(it.order.status, OrderStatus.Filled)
+            assertMyOrdersUpdatedMessageReceived { msg ->
+                assertEquals(1, msg.orders.size)
+                msg.orders.first().let { order ->
+                    assertEquals(inputOrderAmount.inFundamentalUnits, order.amount)
+                    assertEquals(order.status, OrderStatus.Filled)
+                }
             }
             assertBalancesMessageReceived(
                 listOf(
@@ -541,7 +554,9 @@ class BackToBackOrderTest : OrderBaseTest() {
             assertMyTradesCreatedMessageReceived {
                 assertEquals(2, it.trades.size)
             }
-            repeat(2) { assertMyOrderUpdatedMessageReceived() }
+            assertMyOrdersUpdatedMessageReceived {
+                assertEquals(2, it.orders.size)
+            }
             assertBalancesMessageReceived()
             assertLimitsMessageReceived()
         }
@@ -691,7 +706,7 @@ class BackToBackOrderTest : OrderBaseTest() {
         assertEquals(1, limitSellOrder.createdOrders.count { it.requestStatus == RequestStatus.Accepted })
 
         repeat(2) {
-            makerWsClient.assertMyOrderCreatedMessageReceived()
+            makerWsClient.assertMyOrdersCreatedMessageReceived()
             makerWsClient.assertLimitsMessageReceived()
         }
 
@@ -705,7 +720,7 @@ class BackToBackOrderTest : OrderBaseTest() {
         )
 
         takerWsClient.apply {
-            assertMyOrderCreatedMessageReceived()
+            assertMyOrdersCreatedMessageReceived()
             assertMyTradesCreatedMessageReceived {
                 assertEquals(2, it.trades.size)
 
@@ -723,9 +738,12 @@ class BackToBackOrderTest : OrderBaseTest() {
                 assertEquals(BigInteger.ZERO, it.trades[1].feeAmount)
                 assertEquals(eth2.name, it.trades[1].feeSymbol.value)
             }
-            assertMyOrderUpdatedMessageReceived {
-                assertEquals(bridgeOrderAmount.inFundamentalUnits, it.order.amount)
-                assertEquals(it.order.status, OrderStatus.Filled)
+            assertMyOrdersUpdatedMessageReceived { msg ->
+                assertEquals(1, msg.orders.size)
+                msg.orders.first().let { order ->
+                    assertEquals(bridgeOrderAmount.inFundamentalUnits, order.amount)
+                    assertEquals(order.status, OrderStatus.Filled)
+                }
             }
             assertBalancesMessageReceived(
                 listOf(
@@ -740,7 +758,9 @@ class BackToBackOrderTest : OrderBaseTest() {
             assertMyTradesCreatedMessageReceived {
                 assertEquals(2, it.trades.size)
             }
-            repeat(2) { assertMyOrderUpdatedMessageReceived() }
+            assertMyOrdersUpdatedMessageReceived {
+                assertEquals(2, it.orders.size)
+            }
             assertBalancesMessageReceived()
             assertLimitsMessageReceived()
         }

--- a/integrationtests/src/test/kotlin/xyz/funkybit/integrationtests/api/OrderAutoReductionTest.kt
+++ b/integrationtests/src/test/kotlin/xyz/funkybit/integrationtests/api/OrderAutoReductionTest.kt
@@ -10,8 +10,8 @@ import xyz.funkybit.integrationtests.testutils.OrderBaseTest
 import xyz.funkybit.integrationtests.testutils.waitForFinalizedWithdrawal
 import xyz.funkybit.integrationtests.utils.AssetAmount
 import xyz.funkybit.integrationtests.utils.assertBalancesMessageReceived
-import xyz.funkybit.integrationtests.utils.assertMyLimitOrderCreatedMessageReceived
-import xyz.funkybit.integrationtests.utils.assertMyOrderUpdatedMessageReceived
+import xyz.funkybit.integrationtests.utils.assertMyLimitOrdersCreatedMessageReceived
+import xyz.funkybit.integrationtests.utils.assertMyOrdersUpdatedMessageReceived
 import java.math.BigDecimal
 import kotlin.test.Test
 import kotlin.test.assertIs
@@ -46,15 +46,15 @@ class OrderAutoReductionTest : OrderBaseTest() {
             price = BigDecimal("17.500"),
             makerWallet,
         )
-        makerWsClient.assertMyLimitOrderCreatedMessageReceived(limitBuyOrderApiResponse)
+        makerWsClient.assertMyLimitOrdersCreatedMessageReceived(limitBuyOrderApiResponse)
 
         val btcWithdrawalAmount = AssetAmount(btc, "0.1")
 
         val pendingBtcWithdrawal = makerApiClient.createWithdrawal(makerWallet.signWithdraw(btc.name, btcWithdrawalAmount.inFundamentalUnits)).withdrawal
         assertEquals(WithdrawalStatus.Pending, pendingBtcWithdrawal.status)
 
-        makerWsClient.assertMyOrderUpdatedMessageReceived { msg ->
-            msg.order.also { order ->
+        makerWsClient.assertMyOrdersUpdatedMessageReceived { msg ->
+            msg.orders.first().also { order ->
                 assertEquals(limitBuyOrderApiResponse.orderId, order.id)
                 assertIs<Order.Limit>(order)
                 assertTrue(order.autoReduced)

--- a/integrationtests/src/test/kotlin/xyz/funkybit/integrationtests/api/OrderExecutionTest.kt
+++ b/integrationtests/src/test/kotlin/xyz/funkybit/integrationtests/api/OrderExecutionTest.kt
@@ -35,11 +35,11 @@ import xyz.funkybit.integrationtests.utils.assertBalances
 import xyz.funkybit.integrationtests.utils.assertBalancesMessageReceived
 import xyz.funkybit.integrationtests.utils.assertFee
 import xyz.funkybit.integrationtests.utils.assertLimitsMessageReceived
-import xyz.funkybit.integrationtests.utils.assertMyLimitOrderCreatedMessageReceived
-import xyz.funkybit.integrationtests.utils.assertMyMarketOrderCreatedMessageReceived
-import xyz.funkybit.integrationtests.utils.assertMyOrderCreatedMessageReceived
-import xyz.funkybit.integrationtests.utils.assertMyOrderUpdatedMessageReceived
+import xyz.funkybit.integrationtests.utils.assertMyLimitOrdersCreatedMessageReceived
+import xyz.funkybit.integrationtests.utils.assertMyMarketOrdersCreatedMessageReceived
+import xyz.funkybit.integrationtests.utils.assertMyOrdersCreatedMessageReceived
 import xyz.funkybit.integrationtests.utils.assertMyOrdersMessageReceived
+import xyz.funkybit.integrationtests.utils.assertMyOrdersUpdatedMessageReceived
 import xyz.funkybit.integrationtests.utils.assertMyTradesCreatedMessageReceived
 import xyz.funkybit.integrationtests.utils.assertMyTradesMessageReceived
 import xyz.funkybit.integrationtests.utils.assertMyTradesUpdatedMessageReceived
@@ -112,7 +112,7 @@ class OrderExecutionTest : OrderBaseTest() {
             price = BigDecimal("17.500"),
             makerWallet,
         )
-        makerWsClient.assertMyLimitOrderCreatedMessageReceived(limitBuyOrderApiResponse)
+        makerWsClient.assertMyLimitOrdersCreatedMessageReceived(limitBuyOrderApiResponse)
 
         listOf(makerWsClient, takerWsClient).forEach { wsClient ->
             wsClient.assertOrderBookMessageReceived(
@@ -134,10 +134,26 @@ class OrderExecutionTest : OrderBaseTest() {
                     btcbtcArchMarket?.let {
                         MarketLimits(it.id, base = makerStartingBaseBalance.inFundamentalUnits, quote = BigInteger.ZERO)
                     },
-                    MarketLimits(btcbtc2Market.id, base = makerStartingBaseBalance.inFundamentalUnits, quote = BigInteger.ZERO),
-                    MarketLimits(btcEthMarket.id, base = makerStartingBaseBalance.inFundamentalUnits, quote = AssetAmount(eth, "1.99781802125").inFundamentalUnits),
-                    MarketLimits(btcEth2Market.id, base = makerStartingBaseBalance.inFundamentalUnits, quote = BigInteger.ZERO),
-                    MarketLimits(btcUsdcMarket.id, base = makerStartingBaseBalance.inFundamentalUnits, quote = BigInteger.ZERO),
+                    MarketLimits(
+                        btcbtc2Market.id,
+                        base = makerStartingBaseBalance.inFundamentalUnits,
+                        quote = BigInteger.ZERO,
+                    ),
+                    MarketLimits(
+                        btcEthMarket.id,
+                        base = makerStartingBaseBalance.inFundamentalUnits,
+                        quote = AssetAmount(eth, "1.99781802125").inFundamentalUnits,
+                    ),
+                    MarketLimits(
+                        btcEth2Market.id,
+                        base = makerStartingBaseBalance.inFundamentalUnits,
+                        quote = BigInteger.ZERO,
+                    ),
+                    MarketLimits(
+                        btcUsdcMarket.id,
+                        base = makerStartingBaseBalance.inFundamentalUnits,
+                        quote = BigInteger.ZERO,
+                    ),
                     MarketLimits(btc2Eth2Market.id, base = BigInteger.ZERO, quote = BigInteger.ZERO),
                     MarketLimits(btc2Usdc2Market.id, base = BigInteger.ZERO, quote = BigInteger.ZERO),
                     MarketLimits(usdcDaiMarket.id, base = BigInteger.ZERO, quote = BigInteger.ZERO),
@@ -148,12 +164,28 @@ class OrderExecutionTest : OrderBaseTest() {
                     btcbtcArchMarket?.let {
                         MarketLimits(it.id, base = BigInteger.ZERO, quote = BigInteger.ZERO)
                     },
-                    MarketLimits(btcbtc2Market.id, base = BigInteger.ZERO, quote = makerStartingBaseBalance.inFundamentalUnits),
+                    MarketLimits(
+                        btcbtc2Market.id,
+                        base = BigInteger.ZERO,
+                        quote = makerStartingBaseBalance.inFundamentalUnits,
+                    ),
                     MarketLimits(btcEthMarket.id, base = BigInteger.ZERO, quote = BigInteger.ZERO),
-                    MarketLimits(btcEth2Market.id, base = BigInteger.ZERO, quote = makerStartingQuoteBalance.inFundamentalUnits),
+                    MarketLimits(
+                        btcEth2Market.id,
+                        base = BigInteger.ZERO,
+                        quote = makerStartingQuoteBalance.inFundamentalUnits,
+                    ),
                     MarketLimits(btcUsdcMarket.id, base = BigInteger.ZERO, quote = BigInteger.ZERO),
-                    MarketLimits(btc2Eth2Market.id, base = makerStartingBaseBalance.inFundamentalUnits, quote = AssetAmount(eth2, "1.99781802125").inFundamentalUnits),
-                    MarketLimits(btc2Usdc2Market.id, base = makerStartingBaseBalance.inFundamentalUnits, quote = BigInteger.ZERO),
+                    MarketLimits(
+                        btc2Eth2Market.id,
+                        base = makerStartingBaseBalance.inFundamentalUnits,
+                        quote = AssetAmount(eth2, "1.99781802125").inFundamentalUnits,
+                    ),
+                    MarketLimits(
+                        btc2Usdc2Market.id,
+                        base = makerStartingBaseBalance.inFundamentalUnits,
+                        quote = BigInteger.ZERO,
+                    ),
                     MarketLimits(usdcDaiMarket.id, base = BigInteger.ZERO, quote = BigInteger.ZERO),
                     MarketLimits(usdc2Dai2Market.id, base = BigInteger.ZERO, quote = BigInteger.ZERO),
                 )
@@ -169,7 +201,7 @@ class OrderExecutionTest : OrderBaseTest() {
             makerWallet,
         )
 
-        makerWsClient.assertMyLimitOrderCreatedMessageReceived(limitSellOrderApiResponse)
+        makerWsClient.assertMyLimitOrdersCreatedMessageReceived(limitSellOrderApiResponse)
 
         listOf(makerWsClient, takerWsClient).forEach { wsClient ->
             wsClient.assertOrderBookMessageReceived(
@@ -193,10 +225,26 @@ class OrderExecutionTest : OrderBaseTest() {
                     btcbtcArchMarket?.let {
                         MarketLimits(it.id, base = makerStartingBaseBalance.inFundamentalUnits, quote = BigInteger.ZERO)
                     },
-                    MarketLimits(btcbtc2Market.id, base = makerStartingBaseBalance.inFundamentalUnits, quote = BigInteger.ZERO),
-                    MarketLimits(btcEthMarket.id, base = AssetAmount(btc, "0.19945679").inFundamentalUnits, quote = AssetAmount(eth, "1.99781802125").inFundamentalUnits),
-                    MarketLimits(btcEth2Market.id, base = makerStartingBaseBalance.inFundamentalUnits, quote = BigInteger.ZERO),
-                    MarketLimits(btcUsdcMarket.id, base = makerStartingBaseBalance.inFundamentalUnits, quote = BigInteger.ZERO),
+                    MarketLimits(
+                        btcbtc2Market.id,
+                        base = makerStartingBaseBalance.inFundamentalUnits,
+                        quote = BigInteger.ZERO,
+                    ),
+                    MarketLimits(
+                        btcEthMarket.id,
+                        base = AssetAmount(btc, "0.19945679").inFundamentalUnits,
+                        quote = AssetAmount(eth, "1.99781802125").inFundamentalUnits,
+                    ),
+                    MarketLimits(
+                        btcEth2Market.id,
+                        base = makerStartingBaseBalance.inFundamentalUnits,
+                        quote = BigInteger.ZERO,
+                    ),
+                    MarketLimits(
+                        btcUsdcMarket.id,
+                        base = makerStartingBaseBalance.inFundamentalUnits,
+                        quote = BigInteger.ZERO,
+                    ),
                     MarketLimits(btc2Eth2Market.id, base = BigInteger.ZERO, quote = BigInteger.ZERO),
                     MarketLimits(btc2Usdc2Market.id, base = BigInteger.ZERO, quote = BigInteger.ZERO),
                     MarketLimits(usdcDaiMarket.id, base = BigInteger.ZERO, quote = BigInteger.ZERO),
@@ -207,12 +255,28 @@ class OrderExecutionTest : OrderBaseTest() {
                     btcbtcArchMarket?.let {
                         MarketLimits(it.id, base = BigInteger.ZERO, quote = BigInteger.ZERO)
                     },
-                    MarketLimits(btcbtc2Market.id, base = BigInteger.ZERO, quote = makerStartingBaseBalance.inFundamentalUnits),
+                    MarketLimits(
+                        btcbtc2Market.id,
+                        base = BigInteger.ZERO,
+                        quote = makerStartingBaseBalance.inFundamentalUnits,
+                    ),
                     MarketLimits(btcEthMarket.id, base = BigInteger.ZERO, quote = BigInteger.ZERO),
-                    MarketLimits(btcEth2Market.id, base = BigInteger.ZERO, quote = makerStartingQuoteBalance.inFundamentalUnits),
+                    MarketLimits(
+                        btcEth2Market.id,
+                        base = BigInteger.ZERO,
+                        quote = makerStartingQuoteBalance.inFundamentalUnits,
+                    ),
                     MarketLimits(btcUsdcMarket.id, base = BigInteger.ZERO, quote = BigInteger.ZERO),
-                    MarketLimits(btc2Eth2Market.id, base = AssetAmount(btc2, "0.19945679").inFundamentalUnits, quote = AssetAmount(eth2, "1.99781802125").inFundamentalUnits),
-                    MarketLimits(btc2Usdc2Market.id, base = makerStartingBaseBalance.inFundamentalUnits, quote = BigInteger.ZERO),
+                    MarketLimits(
+                        btc2Eth2Market.id,
+                        base = AssetAmount(btc2, "0.19945679").inFundamentalUnits,
+                        quote = AssetAmount(eth2, "1.99781802125").inFundamentalUnits,
+                    ),
+                    MarketLimits(
+                        btc2Usdc2Market.id,
+                        base = makerStartingBaseBalance.inFundamentalUnits,
+                        quote = BigInteger.ZERO,
+                    ),
                     MarketLimits(usdcDaiMarket.id, base = BigInteger.ZERO, quote = BigInteger.ZERO),
                     MarketLimits(usdc2Dai2Market.id, base = BigInteger.ZERO, quote = BigInteger.ZERO),
                 )
@@ -228,7 +292,7 @@ class OrderExecutionTest : OrderBaseTest() {
         )
 
         takerWsClient.apply {
-            assertMyMarketOrderCreatedMessageReceived(marketBuyOrderApiResponse)
+            assertMyMarketOrdersCreatedMessageReceived(marketBuyOrderApiResponse)
             assertMyTradesCreatedMessageReceived(
                 listOf(
                     MyExpectedTrade(
@@ -240,12 +304,15 @@ class OrderExecutionTest : OrderBaseTest() {
                     ),
                 ),
             )
-            assertMyOrderUpdatedMessageReceived { msg ->
-                assertEquals(OrderStatus.Filled, msg.order.status)
-                assertEquals(1, msg.order.executions.size)
-                assertAmount(AssetAmount(baseSymbol, "0.00043210"), msg.order.executions[0].amount)
-                assertAmount(AssetAmount(quoteSymbol, "17.550"), msg.order.executions[0].price)
-                assertEquals(ExecutionRole.Taker, msg.order.executions[0].role)
+            assertMyOrdersUpdatedMessageReceived { msg ->
+                assertEquals(1, msg.orders.size)
+                msg.orders.first().let { order ->
+                    assertEquals(OrderStatus.Filled, order.status)
+                    assertEquals(1, order.executions.size)
+                    assertAmount(AssetAmount(baseSymbol, "0.00043210"), order.executions[0].amount)
+                    assertAmount(AssetAmount(quoteSymbol, "17.550"), order.executions[0].price)
+                    assertEquals(ExecutionRole.Taker, order.executions[0].role)
+                }
             }
             assertBalancesMessageReceived(
                 listOf(
@@ -267,12 +334,15 @@ class OrderExecutionTest : OrderBaseTest() {
                     ),
                 ),
             )
-            assertMyOrderUpdatedMessageReceived { msg ->
-                assertEquals(OrderStatus.Partial, msg.order.status)
-                assertEquals(1, msg.order.executions.size)
-                assertAmount(AssetAmount(baseSymbol, "0.00043210"), msg.order.executions[0].amount)
-                assertAmount(AssetAmount(quoteSymbol, "17.550"), msg.order.executions[0].price)
-                assertEquals(ExecutionRole.Maker, msg.order.executions[0].role)
+            assertMyOrdersUpdatedMessageReceived { msg ->
+                assertEquals(1, msg.orders.size)
+                msg.orders.first().let { order ->
+                    assertEquals(OrderStatus.Partial, order.status)
+                    assertEquals(1, order.executions.size)
+                    assertAmount(AssetAmount(baseSymbol, "0.00043210"), order.executions[0].amount)
+                    assertAmount(AssetAmount(quoteSymbol, "17.550"), order.executions[0].price)
+                    assertEquals(ExecutionRole.Maker, order.executions[0].role)
+                }
             }
             assertBalancesMessageReceived(
                 listOf(
@@ -301,7 +371,10 @@ class OrderExecutionTest : OrderBaseTest() {
         val trade = getTradesForOrders(listOf(marketBuyOrderApiResponse.orderId)).first().also {
             assertAmount(AssetAmount(baseSymbol, "0.00043210"), it.amount)
             assertAmount(AssetAmount(quoteSymbol, "17.550"), it.price)
-            assertEquals(takerApiClient.getOrder(marketBuyOrderApiResponse.orderId).executions.first().tradeId, it.id.value)
+            assertEquals(
+                takerApiClient.getOrder(marketBuyOrderApiResponse.orderId).executions.first().tradeId,
+                it.id.value,
+            )
         }
 
         takerWsClient.apply {
@@ -340,12 +413,32 @@ class OrderExecutionTest : OrderBaseTest() {
                 if (market == btcEthMarket) {
                     listOfNotNull(
                         btcbtcArchMarket?.let {
-                            MarketLimits(it.id, base = AssetAmount(btc, "0.1995679").inFundamentalUnits, quote = BigInteger.ZERO)
+                            MarketLimits(
+                                it.id,
+                                base = AssetAmount(btc, "0.1995679").inFundamentalUnits,
+                                quote = BigInteger.ZERO,
+                            )
                         },
-                        MarketLimits(btcbtc2Market.id, base = AssetAmount(btc, "0.1995679").inFundamentalUnits, quote = BigInteger.ZERO),
-                        MarketLimits(btcEthMarket.id, base = AssetAmount(btc, "0.19945679").inFundamentalUnits, quote = AssetAmount(eth, "2.0053255427").inFundamentalUnits),
-                        MarketLimits(btcEth2Market.id, base = AssetAmount(btc, "0.1995679").inFundamentalUnits, quote = BigInteger.ZERO),
-                        MarketLimits(btcUsdcMarket.id, base = AssetAmount(btc, "0.1995679").inFundamentalUnits, quote = BigInteger.ZERO),
+                        MarketLimits(
+                            btcbtc2Market.id,
+                            base = AssetAmount(btc, "0.1995679").inFundamentalUnits,
+                            quote = BigInteger.ZERO,
+                        ),
+                        MarketLimits(
+                            btcEthMarket.id,
+                            base = AssetAmount(btc, "0.19945679").inFundamentalUnits,
+                            quote = AssetAmount(eth, "2.0053255427").inFundamentalUnits,
+                        ),
+                        MarketLimits(
+                            btcEth2Market.id,
+                            base = AssetAmount(btc, "0.1995679").inFundamentalUnits,
+                            quote = BigInteger.ZERO,
+                        ),
+                        MarketLimits(
+                            btcUsdcMarket.id,
+                            base = AssetAmount(btc, "0.1995679").inFundamentalUnits,
+                            quote = BigInteger.ZERO,
+                        ),
                         MarketLimits(btc2Eth2Market.id, base = BigInteger.ZERO, quote = BigInteger.ZERO),
                         MarketLimits(btc2Usdc2Market.id, base = BigInteger.ZERO, quote = BigInteger.ZERO),
                         MarketLimits(usdcDaiMarket.id, base = BigInteger.ZERO, quote = BigInteger.ZERO),
@@ -356,12 +449,28 @@ class OrderExecutionTest : OrderBaseTest() {
                         btcbtcArchMarket?.let {
                             MarketLimits(it.id, base = BigInteger.ZERO, quote = BigInteger.ZERO)
                         },
-                        MarketLimits(btcbtc2Market.id, base = BigInteger.ZERO, quote = AssetAmount(btc2, "0.1995679").inFundamentalUnits),
+                        MarketLimits(
+                            btcbtc2Market.id,
+                            base = BigInteger.ZERO,
+                            quote = AssetAmount(btc2, "0.1995679").inFundamentalUnits,
+                        ),
                         MarketLimits(btcEthMarket.id, base = BigInteger.ZERO, quote = BigInteger.ZERO),
-                        MarketLimits(btcEth2Market.id, base = BigInteger.ZERO, quote = AssetAmount(eth2, "2.00750752145").inFundamentalUnits),
+                        MarketLimits(
+                            btcEth2Market.id,
+                            base = BigInteger.ZERO,
+                            quote = AssetAmount(eth2, "2.00750752145").inFundamentalUnits,
+                        ),
                         MarketLimits(btcUsdcMarket.id, base = BigInteger.ZERO, quote = BigInteger.ZERO),
-                        MarketLimits(btc2Eth2Market.id, base = AssetAmount(btc2, "0.19945679").inFundamentalUnits, quote = AssetAmount(eth2, "2.0053255427").inFundamentalUnits),
-                        MarketLimits(btc2Usdc2Market.id, base = AssetAmount(btc2, "0.1995679").inFundamentalUnits, quote = BigInteger.ZERO),
+                        MarketLimits(
+                            btc2Eth2Market.id,
+                            base = AssetAmount(btc2, "0.19945679").inFundamentalUnits,
+                            quote = AssetAmount(eth2, "2.0053255427").inFundamentalUnits,
+                        ),
+                        MarketLimits(
+                            btc2Usdc2Market.id,
+                            base = AssetAmount(btc2, "0.1995679").inFundamentalUnits,
+                            quote = BigInteger.ZERO,
+                        ),
                         MarketLimits(usdcDaiMarket.id, base = BigInteger.ZERO, quote = BigInteger.ZERO),
                         MarketLimits(usdc2Dai2Market.id, base = BigInteger.ZERO, quote = BigInteger.ZERO),
                     )
@@ -424,7 +533,7 @@ class OrderExecutionTest : OrderBaseTest() {
         )
 
         takerWsClient.apply {
-            assertMyMarketOrderCreatedMessageReceived(marketSellOrderApiResponse)
+            assertMyMarketOrdersCreatedMessageReceived(marketSellOrderApiResponse)
             assertMyTradesCreatedMessageReceived(
                 listOf(
                     MyExpectedTrade(
@@ -436,17 +545,24 @@ class OrderExecutionTest : OrderBaseTest() {
                     ),
                 ),
             )
-            assertMyOrderUpdatedMessageReceived { msg ->
-                assertEquals(OrderStatus.Partial, msg.order.status)
-                assertEquals(1, msg.order.executions.size)
-                assertAmount(AssetAmount(baseSymbol, "0.00012345"), msg.order.executions[0].amount)
-                assertAmount(AssetAmount(quoteSymbol, "17.500"), msg.order.executions[0].price)
-                assertEquals(ExecutionRole.Taker, msg.order.executions[0].role)
+            assertMyOrdersUpdatedMessageReceived { msg ->
+                assertEquals(1, msg.orders.size)
+                msg.orders.first().let { order ->
+                    assertEquals(OrderStatus.Partial, order.status)
+                    assertEquals(1, order.executions.size)
+                    assertAmount(AssetAmount(baseSymbol, "0.00012345"), order.executions[0].amount)
+                    assertAmount(AssetAmount(quoteSymbol, "17.500"), order.executions[0].price)
+                    assertEquals(ExecutionRole.Taker, order.executions[0].role)
+                }
             }
             assertBalancesMessageReceived(
                 listOf(
                     ExpectedBalance(baseSymbol, total = BigDecimal("0.0004321"), available = BigDecimal("0.00030865")),
-                    ExpectedBalance(quoteSymbol, total = BigDecimal("1.9922649779"), available = BigDecimal("1.9943821454")),
+                    ExpectedBalance(
+                        quoteSymbol,
+                        total = BigDecimal("1.9922649779"),
+                        available = BigDecimal("1.9943821454"),
+                    ),
                 ),
             )
         }
@@ -463,17 +579,24 @@ class OrderExecutionTest : OrderBaseTest() {
                     ),
                 ),
             )
-            assertMyOrderUpdatedMessageReceived { msg ->
-                assertEquals(OrderStatus.Filled, msg.order.status)
-                assertEquals(1, msg.order.executions.size)
-                assertAmount(AssetAmount(baseSymbol, "0.00012345"), msg.order.executions[0].amount)
-                assertAmount(AssetAmount(quoteSymbol, "17.500"), msg.order.executions[0].price)
-                assertEquals(ExecutionRole.Maker, msg.order.executions[0].role)
+            assertMyOrdersUpdatedMessageReceived { msg ->
+                assertEquals(1, msg.orders.size)
+                msg.orders.first().let { order ->
+                    assertEquals(OrderStatus.Filled, order.status)
+                    assertEquals(1, order.executions.size)
+                    assertAmount(AssetAmount(baseSymbol, "0.00012345"), order.executions[0].amount)
+                    assertAmount(AssetAmount(quoteSymbol, "17.500"), order.executions[0].price)
+                    assertEquals(ExecutionRole.Maker, order.executions[0].role)
+                }
             }
             assertBalancesMessageReceived(
                 listOf(
                     ExpectedBalance(baseSymbol, total = BigDecimal("0.1995679"), available = BigDecimal("0.19969135")),
-                    ExpectedBalance(quoteSymbol, total = BigDecimal("2.00750752145"), available = BigDecimal("2.0053255427")),
+                    ExpectedBalance(
+                        quoteSymbol,
+                        total = BigDecimal("2.00750752145"),
+                        available = BigDecimal("2.0053255427"),
+                    ),
                 ),
             )
         }
@@ -575,19 +698,35 @@ class OrderExecutionTest : OrderBaseTest() {
             }
         }
 
-        val takerOrderCount = takerApiClient.listOrders(statuses = listOf(OrderStatus.Open, OrderStatus.Partial)).orders.filterNot { it is Order.Market }.size
+        val takerOrderCount = takerApiClient.listOrders(
+            statuses = listOf(
+                OrderStatus.Open,
+                OrderStatus.Partial,
+            ),
+        ).orders.filterNot { it is Order.Market }.size
         takerApiClient.cancelOpenOrders()
         repeat(takerOrderCount) {
-            takerWsClient.assertMyOrderUpdatedMessageReceived { msg ->
-                assertEquals(OrderStatus.Cancelled, msg.order.status)
+            takerWsClient.assertMyOrdersUpdatedMessageReceived { msg ->
+                assertEquals(1, msg.orders.size)
+                msg.orders.first().let { order ->
+                    assertEquals(OrderStatus.Cancelled, order.status)
+                }
             }
         }
 
-        val makerOrderCount = makerApiClient.listOrders(statuses = listOf(OrderStatus.Open, OrderStatus.Partial)).orders.filterNot { it is Order.Market }.size
+        val makerOrderCount = makerApiClient.listOrders(
+            statuses = listOf(
+                OrderStatus.Open,
+                OrderStatus.Partial,
+            ),
+        ).orders.filterNot { it is Order.Market }.size
         makerApiClient.cancelOpenOrders()
         repeat(makerOrderCount) {
-            makerWsClient.assertMyOrderUpdatedMessageReceived { msg ->
-                assertEquals(OrderStatus.Cancelled, msg.order.status)
+            makerWsClient.assertMyOrdersUpdatedMessageReceived { msg ->
+                assertEquals(1, msg.orders.size)
+                msg.orders.first().let { order ->
+                    assertEquals(OrderStatus.Cancelled, order.status)
+                }
             }
         }
 
@@ -646,7 +785,12 @@ class OrderExecutionTest : OrderBaseTest() {
                     assertEquals(marketBuyOrderApiResponse.orderId, orderId)
                     assertEquals(marketBuyOrderApiResponse.order.marketId, marketId)
                     assertEquals(marketBuyOrderApiResponse.order.side, side)
-                    assertAmount((limitSellOrderApiResponse.order as CreateOrderApiRequest.Limit).price.ofAsset(quoteSymbol), price)
+                    assertAmount(
+                        (limitSellOrderApiResponse.order as CreateOrderApiRequest.Limit).price.ofAsset(
+                            quoteSymbol,
+                        ),
+                        price,
+                    )
                     assertAmount(AssetAmount(baseSymbol, marketBuyOrderApiResponse.order.amount.fixedAmount()), amount)
                     assertFee(AssetAmount(quoteSymbol, "0.0001516671"), feeAmount, feeSymbol)
                     assertEquals(SettlementStatus.Completed, settlementStatus)
@@ -740,7 +884,9 @@ class OrderExecutionTest : OrderBaseTest() {
         )
 
         assertEquals(3, createBatchLimitOrders.createdOrders.count())
-        repeat(3) { makerWsClient.assertMyOrderCreatedMessageReceived() }
+        makerWsClient.assertMyOrdersCreatedMessageReceived {
+            assertEquals(3, it.orders.size)
+        }
         makerWsClient
             .assertLimitsMessageReceived(market, base = BigDecimal("0.194"), quote = BigDecimal("500"))
             .also { wsMessage -> verifyApiReturnsSameLimits(makerApiClient, wsMessage) }
@@ -782,8 +928,10 @@ class OrderExecutionTest : OrderBaseTest() {
         assertEquals(1, batchOrderResponse.canceledOrders.count { it.requestStatus == RequestStatus.Accepted })
         assertEquals(1, batchOrderResponse.canceledOrders.count { it.requestStatus == RequestStatus.Rejected })
 
-        repeat(3) { makerWsClient.assertMyOrderCreatedMessageReceived() }
-        makerWsClient.assertMyOrderUpdatedMessageReceived()
+        makerWsClient.assertMyOrdersCreatedMessageReceived {
+            assertEquals(3, it.orders.size)
+        }
+        makerWsClient.assertMyOrdersUpdatedMessageReceived()
         makerWsClient
             .assertLimitsMessageReceived(market, base = BigDecimal("0.182"), quote = BigDecimal("500"))
             .also { wsMessage -> verifyApiReturnsSameLimits(makerApiClient, wsMessage) }
@@ -801,11 +949,11 @@ class OrderExecutionTest : OrderBaseTest() {
         )
 
         takerWsClient.apply {
-            assertMyOrderCreatedMessageReceived()
+            assertMyOrdersCreatedMessageReceived()
             assertMyTradesCreatedMessageReceived { msg ->
                 assertEquals(5, msg.trades.size)
             }
-            assertMyOrderUpdatedMessageReceived()
+            assertMyOrdersUpdatedMessageReceived()
             assertBalancesMessageReceived()
             assertPricesMessageReceived(market.id) { msg ->
                 assertEquals(
@@ -830,7 +978,9 @@ class OrderExecutionTest : OrderBaseTest() {
             assertMyTradesCreatedMessageReceived { msg ->
                 assertEquals(5, msg.trades.size)
             }
-            repeat(5) { assertMyOrderUpdatedMessageReceived() }
+            assertMyOrdersUpdatedMessageReceived { msg ->
+                assertEquals(5, msg.orders.size)
+            }
             assertBalancesMessageReceived()
             assertPricesMessageReceived(market.id) { msg ->
                 assertEquals(
@@ -856,7 +1006,8 @@ class OrderExecutionTest : OrderBaseTest() {
 
         // now verify the trades
 
-        val expectedAmounts = listOf("0.001", "0.002", "0.004", "0.005", "0.006").map { AssetAmount(baseSymbol, it) }.toSet()
+        val expectedAmounts =
+            listOf("0.001", "0.002", "0.004", "0.005", "0.006").map { AssetAmount(baseSymbol, it) }.toSet()
         val trades = getTradesForOrders(takerOrders.map { it.id })
         val prices = trades.map { it.price }.toSet()
 
@@ -945,7 +1096,7 @@ class OrderExecutionTest : OrderBaseTest() {
             makerWallet,
         )
         makerWsClient.apply {
-            assertMyLimitOrderCreatedMessageReceived(limitBuyOrderApiResponse)
+            assertMyLimitOrdersCreatedMessageReceived(limitBuyOrderApiResponse)
             assertLimitsMessageReceived(market, base = BigDecimal("0.4"), quote = BigDecimal("0.4789212"))
         }
 
@@ -959,7 +1110,7 @@ class OrderExecutionTest : OrderBaseTest() {
         )
 
         makerWsClient.apply {
-            assertMyLimitOrderCreatedMessageReceived(limitSellOrderApiResponse)
+            assertMyLimitOrdersCreatedMessageReceived(limitSellOrderApiResponse)
             assertLimitsMessageReceived(market, base = BigDecimal("0.180"), quote = BigDecimal("0.4789212"))
         }
 
@@ -972,7 +1123,7 @@ class OrderExecutionTest : OrderBaseTest() {
         )
 
         takerWsClient.apply {
-            assertMyMarketOrderCreatedMessageReceived(marketBuyOrderApiResponse)
+            assertMyMarketOrdersCreatedMessageReceived(marketBuyOrderApiResponse)
             assertMyTradesCreatedMessageReceived(
                 listOf(
                     MyExpectedTrade(
@@ -984,12 +1135,15 @@ class OrderExecutionTest : OrderBaseTest() {
                     ),
                 ),
             )
-            assertMyOrderUpdatedMessageReceived { msg ->
-                assertEquals(OrderStatus.Filled, msg.order.status)
-                assertEquals(1, msg.order.executions.size)
-                assertAmount(AssetAmount(baseSymbol, "0.05"), msg.order.executions[0].amount)
-                assertAmount(AssetAmount(quoteSymbol, "1.002"), msg.order.executions[0].price)
-                assertEquals(ExecutionRole.Taker, msg.order.executions[0].role)
+            assertMyOrdersUpdatedMessageReceived { msg ->
+                assertEquals(1, msg.orders.size)
+                msg.orders.first().let { order ->
+                    assertEquals(OrderStatus.Filled, order.status)
+                    assertEquals(1, order.executions.size)
+                    assertAmount(AssetAmount(baseSymbol, "0.05"), order.executions[0].amount)
+                    assertAmount(AssetAmount(quoteSymbol, "1.002"), order.executions[0].price)
+                    assertEquals(ExecutionRole.Taker, order.executions[0].role)
+                }
             }
             assertBalancesMessageReceived(
                 listOf(
@@ -1011,12 +1165,15 @@ class OrderExecutionTest : OrderBaseTest() {
                     ),
                 ),
             )
-            assertMyOrderUpdatedMessageReceived { msg ->
-                assertEquals(OrderStatus.Partial, msg.order.status)
-                assertEquals(1, msg.order.executions.size)
-                assertAmount(AssetAmount(baseSymbol, "0.05"), msg.order.executions[0].amount)
-                assertAmount(AssetAmount(quoteSymbol, "1.002"), msg.order.executions[0].price)
-                assertEquals(ExecutionRole.Maker, msg.order.executions[0].role)
+            assertMyOrdersUpdatedMessageReceived { msg ->
+                assertEquals(1, msg.orders.size)
+                msg.orders.first().let { order ->
+                    assertEquals(OrderStatus.Partial, order.status)
+                    assertEquals(1, order.executions.size)
+                    assertAmount(AssetAmount(baseSymbol, "0.05"), order.executions[0].amount)
+                    assertAmount(AssetAmount(quoteSymbol, "1.002"), order.executions[0].price)
+                    assertEquals(ExecutionRole.Maker, order.executions[0].role)
+                }
             }
             assertBalancesMessageReceived(
                 listOf(
@@ -1094,7 +1251,7 @@ class OrderExecutionTest : OrderBaseTest() {
         )
 
         takerWsClient.apply {
-            assertMyMarketOrderCreatedMessageReceived(marketSellOrderApiResponse)
+            assertMyMarketOrdersCreatedMessageReceived(marketSellOrderApiResponse)
             assertMyTradesCreatedMessageReceived(
                 listOf(
                     MyExpectedTrade(
@@ -1106,17 +1263,24 @@ class OrderExecutionTest : OrderBaseTest() {
                     ),
                 ),
             )
-            assertMyOrderUpdatedMessageReceived { msg ->
-                assertEquals(OrderStatus.Filled, msg.order.status)
-                assertEquals(1, msg.order.executions.size)
-                assertAmount(AssetAmount(baseSymbol, "0.012345"), msg.order.executions[0].amount)
-                assertAmount(AssetAmount(quoteSymbol, "0.999"), msg.order.executions[0].price)
-                assertEquals(ExecutionRole.Taker, msg.order.executions[0].role)
+            assertMyOrdersUpdatedMessageReceived { msg ->
+                assertEquals(1, msg.orders.size)
+                msg.orders.first().let { order ->
+                    assertEquals(OrderStatus.Filled, order.status)
+                    assertEquals(1, order.executions.size)
+                    assertAmount(AssetAmount(baseSymbol, "0.012345"), order.executions[0].amount)
+                    assertAmount(AssetAmount(quoteSymbol, "0.999"), order.executions[0].price)
+                    assertEquals(ExecutionRole.Taker, order.executions[0].role)
+                }
             }
             assertBalancesMessageReceived(
                 listOf(
                     ExpectedBalance(baseSymbol, total = BigDecimal("0.05"), available = BigDecimal("0.037655")),
-                    ExpectedBalance(quoteSymbol, total = BigDecimal("0.448898"), available = BigDecimal("0.4609840019")),
+                    ExpectedBalance(
+                        quoteSymbol,
+                        total = BigDecimal("0.448898"),
+                        available = BigDecimal("0.4609840019"),
+                    ),
                 ),
             )
         }
@@ -1133,17 +1297,24 @@ class OrderExecutionTest : OrderBaseTest() {
                     ),
                 ),
             )
-            assertMyOrderUpdatedMessageReceived { msg ->
-                assertEquals(OrderStatus.Partial, msg.order.status)
-                assertEquals(1, msg.order.executions.size)
-                assertAmount(AssetAmount(baseSymbol, "0.012345"), msg.order.executions[0].amount)
-                assertAmount(AssetAmount(quoteSymbol, "0.999"), msg.order.executions[0].price)
-                assertEquals(ExecutionRole.Maker, msg.order.executions[0].role)
+            assertMyOrdersUpdatedMessageReceived { msg ->
+                assertEquals(1, msg.orders.size)
+                msg.orders.first().let { order ->
+                    assertEquals(OrderStatus.Partial, order.status)
+                    assertEquals(1, order.executions.size)
+                    assertAmount(AssetAmount(baseSymbol, "0.012345"), order.executions[0].amount)
+                    assertAmount(AssetAmount(quoteSymbol, "0.999"), order.executions[0].price)
+                    assertEquals(ExecutionRole.Maker, order.executions[0].role)
+                }
             }
             assertBalancesMessageReceived(
                 listOf(
                     ExpectedBalance(baseSymbol, total = BigDecimal("0.35"), available = BigDecimal("0.362345")),
-                    ExpectedBalance(quoteSymbol, total = BigDecimal("0.649599"), available = BigDecimal("0.63714301845")),
+                    ExpectedBalance(
+                        quoteSymbol,
+                        total = BigDecimal("0.649599"),
+                        available = BigDecimal("0.63714301845"),
+                    ),
                 ),
             )
         }
@@ -1281,7 +1452,9 @@ class OrderExecutionTest : OrderBaseTest() {
         )
 
         assertEquals(3, createBatchLimitOrders.createdOrders.count())
-        repeat(3) { makerWsClient.assertMyOrderCreatedMessageReceived() }
+        makerWsClient.assertMyOrdersCreatedMessageReceived {
+            assertEquals(3, it.orders.size)
+        }
         makerWsClient.assertLimitsMessageReceived(market, base = BigDecimal("0.1940"), quote = BigDecimal("1.8"))
 
         val batchOrderResponse = makerApiClient.batchOrders(
@@ -1321,8 +1494,10 @@ class OrderExecutionTest : OrderBaseTest() {
         assertEquals(1, batchOrderResponse.canceledOrders.count { it.requestStatus == RequestStatus.Accepted })
         assertEquals(1, batchOrderResponse.canceledOrders.count { it.requestStatus == RequestStatus.Rejected })
 
-        repeat(3) { makerWsClient.assertMyOrderCreatedMessageReceived() }
-        makerWsClient.assertMyOrderUpdatedMessageReceived()
+        makerWsClient.assertMyOrdersCreatedMessageReceived {
+            assertEquals(3, it.orders.size)
+        }
+        makerWsClient.assertMyOrdersUpdatedMessageReceived()
         makerWsClient.assertLimitsMessageReceived(market, base = BigDecimal("0.182"), quote = BigDecimal("1.8"))
 
         assertEquals(5, makerApiClient.listOrders().orders.count { it.status == OrderStatus.Open })
@@ -1338,11 +1513,11 @@ class OrderExecutionTest : OrderBaseTest() {
         )
 
         takerWsClient.apply {
-            assertMyOrderCreatedMessageReceived()
+            assertMyOrdersCreatedMessageReceived()
             assertMyTradesCreatedMessageReceived { msg ->
                 assertEquals(5, msg.trades.size)
             }
-            assertMyOrderUpdatedMessageReceived()
+            assertMyOrdersUpdatedMessageReceived()
             assertBalancesMessageReceived()
             assertLimitsMessageReceived(market, base = BigDecimal("0.018"), quote = BigDecimal("1.78162164"))
         }
@@ -1351,7 +1526,9 @@ class OrderExecutionTest : OrderBaseTest() {
             assertMyTradesCreatedMessageReceived { msg ->
                 assertEquals(5, msg.trades.size)
             }
-            repeat(5) { assertMyOrderUpdatedMessageReceived() }
+            assertMyOrdersUpdatedMessageReceived { msg ->
+                assertEquals(5, msg.orders.size)
+            }
             assertBalancesMessageReceived()
             assertLimitsMessageReceived(market, base = BigDecimal("0.182"), quote = BigDecimal("1.81783782"))
         }
@@ -1363,7 +1540,8 @@ class OrderExecutionTest : OrderBaseTest() {
 
         // now verify the trades
 
-        val expectedAmounts = listOf("0.001", "0.002", "0.004", "0.005", "0.006").map { AssetAmount(baseSymbol, it) }.toSet()
+        val expectedAmounts =
+            listOf("0.001", "0.002", "0.004", "0.005", "0.006").map { AssetAmount(baseSymbol, it) }.toSet()
         val trades = getTradesForOrders(takerOrders.map { it.id })
         val prices = trades.map { it.price }.toSet()
 

--- a/integrationtests/src/test/kotlin/xyz/funkybit/integrationtests/api/OrderPercentageSwapTest.kt
+++ b/integrationtests/src/test/kotlin/xyz/funkybit/integrationtests/api/OrderPercentageSwapTest.kt
@@ -24,8 +24,8 @@ import xyz.funkybit.integrationtests.utils.ExpectedBalance
 import xyz.funkybit.integrationtests.utils.assertBalances
 import xyz.funkybit.integrationtests.utils.assertBalancesMessageReceived
 import xyz.funkybit.integrationtests.utils.assertLimitsMessageReceived
-import xyz.funkybit.integrationtests.utils.assertMyOrderCreatedMessageReceived
-import xyz.funkybit.integrationtests.utils.assertMyOrderUpdatedMessageReceived
+import xyz.funkybit.integrationtests.utils.assertMyOrdersCreatedMessageReceived
+import xyz.funkybit.integrationtests.utils.assertMyOrdersUpdatedMessageReceived
 import xyz.funkybit.integrationtests.utils.assertMyTradesCreatedMessageReceived
 import xyz.funkybit.integrationtests.utils.ofAsset
 import xyz.funkybit.integrationtests.utils.sum
@@ -94,7 +94,9 @@ class OrderPercentageSwapTest : OrderBaseTest() {
 
         assertEquals(4, createBatchLimitOrders.createdOrders.count { it.requestStatus == RequestStatus.Accepted })
 
-        repeat(4) { makerWsClient.assertMyOrderCreatedMessageReceived() }
+        makerWsClient.assertMyOrdersCreatedMessageReceived {
+            assertEquals(4, it.orders.size)
+        }
         makerWsClient.assertLimitsMessageReceived(market, base = BigDecimal.ZERO, quote = BigDecimal("10314.1"))
 
         assertEquals(4, makerApiClient.listOrders(listOf(OrderStatus.Open), null).orders.size)
@@ -110,12 +112,15 @@ class OrderPercentageSwapTest : OrderBaseTest() {
         )
 
         takerWsClient.apply {
-            assertMyOrderCreatedMessageReceived()
+            assertMyOrdersCreatedMessageReceived()
             assertMyTradesCreatedMessageReceived { msg ->
                 assertEquals(4, msg.trades.size)
             }
-            assertMyOrderUpdatedMessageReceived {
-                assertEquals(BigDecimal("0.1").toFundamentalUnits(market.baseDecimals), it.order.amount)
+            assertMyOrdersUpdatedMessageReceived { msg ->
+                assertEquals(1, msg.orders.size)
+                msg.orders.first().let { order ->
+                    assertEquals(BigDecimal("0.1").toFundamentalUnits(market.baseDecimals), order.amount)
+                }
             }
             assertBalancesMessageReceived {
                 listOf(
@@ -130,7 +135,9 @@ class OrderPercentageSwapTest : OrderBaseTest() {
             assertMyTradesCreatedMessageReceived { msg ->
                 assertEquals(4, msg.trades.size)
             }
-            repeat(4) { assertMyOrderUpdatedMessageReceived() }
+            assertMyOrdersUpdatedMessageReceived { msg ->
+                assertEquals(4, msg.orders.size)
+            }
             assertBalancesMessageReceived()
             assertLimitsMessageReceived(market, base = BigDecimal("0.1"), quote = BigDecimal("10314.1"))
         }
@@ -235,7 +242,9 @@ class OrderPercentageSwapTest : OrderBaseTest() {
 
         assertEquals(4, createBatchLimitOrders.createdOrders.count { it.requestStatus == RequestStatus.Accepted })
 
-        repeat(4) { makerWsClient.assertMyOrderCreatedMessageReceived() }
+        makerWsClient.assertMyOrdersCreatedMessageReceived {
+            assertEquals(4, it.orders.size)
+        }
         makerWsClient.assertLimitsMessageReceived(market, base = BigDecimal("0.06"), quote = BigDecimal("0"))
 
         assertEquals(4, makerApiClient.listOrders(listOf(OrderStatus.Open), null).orders.size)
@@ -252,11 +261,11 @@ class OrderPercentageSwapTest : OrderBaseTest() {
         )
 
         takerWsClient.apply {
-            assertMyOrderCreatedMessageReceived()
+            assertMyOrdersCreatedMessageReceived()
             assertMyTradesCreatedMessageReceived { msg ->
                 assertEquals(4, msg.trades.size)
             }
-            assertMyOrderUpdatedMessageReceived()
+            assertMyOrdersUpdatedMessageReceived()
             assertBalancesMessageReceived()
             assertLimitsMessageReceived(market, base = BigDecimal("0.1"), quote = BigDecimal("0"))
         }
@@ -265,7 +274,9 @@ class OrderPercentageSwapTest : OrderBaseTest() {
             assertMyTradesCreatedMessageReceived { msg ->
                 assertEquals(4, msg.trades.size)
             }
-            repeat(4) { assertMyOrderUpdatedMessageReceived() }
+            assertMyOrdersUpdatedMessageReceived { msg ->
+                assertEquals(4, msg.orders.size)
+            }
             assertBalancesMessageReceived()
             assertLimitsMessageReceived(market, base = BigDecimal("0.06"), quote = BigDecimal("6781.5"))
         }
@@ -370,7 +381,9 @@ class OrderPercentageSwapTest : OrderBaseTest() {
             ),
         )
 
-        repeat(limitOrders.size) { makerWsClient.assertMyOrderCreatedMessageReceived() }
+        makerWsClient.assertMyOrdersCreatedMessageReceived {
+            assertEquals(limitOrders.size, it.orders.size)
+        }
         makerWsClient.assertLimitsMessageReceived()
 
         assertEquals(limitOrders.size, makerApiClient.listOrders(listOf(OrderStatus.Open), null).orders.size)
@@ -384,11 +397,11 @@ class OrderPercentageSwapTest : OrderBaseTest() {
         )
 
         takerWsClient.apply {
-            assertMyOrderCreatedMessageReceived()
+            assertMyOrdersCreatedMessageReceived()
             assertMyTradesCreatedMessageReceived { msg ->
                 assertEquals(limitOrders.size, msg.trades.size)
             }
-            assertMyOrderUpdatedMessageReceived()
+            assertMyOrdersUpdatedMessageReceived()
             assertBalancesMessageReceived()
             assertLimitsMessageReceived()
         }
@@ -397,7 +410,9 @@ class OrderPercentageSwapTest : OrderBaseTest() {
             assertMyTradesCreatedMessageReceived { msg ->
                 assertEquals(limitOrders.size, msg.trades.size)
             }
-            repeat(limitOrders.size) { assertMyOrderUpdatedMessageReceived() }
+            assertMyOrdersUpdatedMessageReceived { msg ->
+                assertEquals(limitOrders.size, msg.orders.size)
+            }
             assertBalancesMessageReceived()
             assertLimitsMessageReceived()
         }

--- a/integrationtests/src/test/kotlin/xyz/funkybit/integrationtests/bitcoin/ArchSettlementTest.kt
+++ b/integrationtests/src/test/kotlin/xyz/funkybit/integrationtests/bitcoin/ArchSettlementTest.kt
@@ -34,9 +34,9 @@ import xyz.funkybit.integrationtests.utils.assertAmount
 import xyz.funkybit.integrationtests.utils.assertBalances
 import xyz.funkybit.integrationtests.utils.assertBalancesMessageReceived
 import xyz.funkybit.integrationtests.utils.assertLimitsMessageReceived
-import xyz.funkybit.integrationtests.utils.assertMyLimitOrderCreatedMessageReceived
-import xyz.funkybit.integrationtests.utils.assertMyMarketOrderCreatedMessageReceived
-import xyz.funkybit.integrationtests.utils.assertMyOrderUpdatedMessageReceived
+import xyz.funkybit.integrationtests.utils.assertMyLimitOrdersCreatedMessageReceived
+import xyz.funkybit.integrationtests.utils.assertMyMarketOrdersCreatedMessageReceived
+import xyz.funkybit.integrationtests.utils.assertMyOrdersUpdatedMessageReceived
 import xyz.funkybit.integrationtests.utils.assertMyTradesCreatedMessageReceived
 import xyz.funkybit.integrationtests.utils.assertMyTradesUpdatedMessageReceived
 import xyz.funkybit.integrationtests.utils.ofAsset
@@ -110,7 +110,7 @@ class ArchSettlementTest : OrderBaseTest() {
             makerBitcoinWallet,
         )
         makerWsClient.apply {
-            assertMyLimitOrderCreatedMessageReceived(limitSellOrderApiResponse)
+            assertMyLimitOrdersCreatedMessageReceived(limitSellOrderApiResponse)
             assertLimitsMessageReceived(market, base = BigDecimal("0.59997"), quote = BigDecimal("0"))
         }
 
@@ -123,7 +123,7 @@ class ArchSettlementTest : OrderBaseTest() {
         )
 
         takerWsClient.apply {
-            assertMyMarketOrderCreatedMessageReceived(marketBuyOrderApiResponse)
+            assertMyMarketOrdersCreatedMessageReceived(marketBuyOrderApiResponse)
             assertMyTradesCreatedMessageReceived(
                 listOf(
                     MyExpectedTrade(
@@ -135,12 +135,15 @@ class ArchSettlementTest : OrderBaseTest() {
                     ),
                 ),
             )
-            assertMyOrderUpdatedMessageReceived { msg ->
-                Assertions.assertEquals(OrderStatus.Filled, msg.order.status)
-                Assertions.assertEquals(1, msg.order.executions.size)
-                assertAmount(AssetAmount(baseSymbol, "0.00003"), msg.order.executions[0].amount)
-                assertAmount(AssetAmount(quoteSymbol, "0.999"), msg.order.executions[0].price)
-                Assertions.assertEquals(ExecutionRole.Taker, msg.order.executions[0].role)
+            assertMyOrdersUpdatedMessageReceived { msg ->
+                Assertions.assertEquals(1, msg.orders.size)
+                msg.orders.first().let { order ->
+                    Assertions.assertEquals(OrderStatus.Filled, order.status)
+                    Assertions.assertEquals(1, order.executions.size)
+                    assertAmount(AssetAmount(baseSymbol, "0.00003"), order.executions[0].amount)
+                    assertAmount(AssetAmount(quoteSymbol, "0.999"), order.executions[0].price)
+                    Assertions.assertEquals(ExecutionRole.Taker, order.executions[0].role)
+                }
             }
             assertBalancesMessageReceived(
                 listOf(
@@ -162,12 +165,15 @@ class ArchSettlementTest : OrderBaseTest() {
                     ),
                 ),
             )
-            assertMyOrderUpdatedMessageReceived { msg ->
-                Assertions.assertEquals(OrderStatus.Filled, msg.order.status)
-                Assertions.assertEquals(1, msg.order.executions.size)
-                assertAmount(AssetAmount(baseSymbol, "0.00003"), msg.order.executions[0].amount)
-                assertAmount(AssetAmount(quoteSymbol, "0.999"), msg.order.executions[0].price)
-                Assertions.assertEquals(ExecutionRole.Maker, msg.order.executions[0].role)
+            assertMyOrdersUpdatedMessageReceived { msg ->
+                Assertions.assertEquals(1, msg.orders.size)
+                msg.orders.first().let { order ->
+                    Assertions.assertEquals(OrderStatus.Filled, order.status)
+                    Assertions.assertEquals(1, order.executions.size)
+                    assertAmount(AssetAmount(baseSymbol, "0.00003"), order.executions[0].amount)
+                    assertAmount(AssetAmount(quoteSymbol, "0.999"), order.executions[0].price)
+                    Assertions.assertEquals(ExecutionRole.Maker, order.executions[0].role)
+                }
             }
             assertBalancesMessageReceived(
                 listOf(
@@ -289,7 +295,7 @@ class ArchSettlementTest : OrderBaseTest() {
             makerEvmWallet,
         )
         makerWsClient.apply {
-            assertMyLimitOrderCreatedMessageReceived(limitBuyOrderApiResponse)
+            assertMyLimitOrdersCreatedMessageReceived(limitBuyOrderApiResponse)
             assertLimitsMessageReceived(market, base = BigDecimal("0"), quote = BigDecimal("0.00001974"))
         }
 
@@ -302,7 +308,7 @@ class ArchSettlementTest : OrderBaseTest() {
         )
 
         takerWsClient.apply {
-            assertMyMarketOrderCreatedMessageReceived(marketSellOrderApiResponse)
+            assertMyMarketOrdersCreatedMessageReceived(marketSellOrderApiResponse)
             assertMyTradesCreatedMessageReceived(
                 listOf(
                     MyExpectedTrade(
@@ -314,12 +320,15 @@ class ArchSettlementTest : OrderBaseTest() {
                     ),
                 ),
             )
-            assertMyOrderUpdatedMessageReceived { msg ->
-                Assertions.assertEquals(OrderStatus.Filled, msg.order.status)
-                Assertions.assertEquals(1, msg.order.executions.size)
-                assertAmount(AssetAmount(baseSymbol, "0.00003"), msg.order.executions[0].amount)
-                assertAmount(AssetAmount(quoteSymbol, "0.999"), msg.order.executions[0].price)
-                Assertions.assertEquals(ExecutionRole.Taker, msg.order.executions[0].role)
+            assertMyOrdersUpdatedMessageReceived { msg ->
+                Assertions.assertEquals(1, msg.orders.size)
+                msg.orders.first().let { order ->
+                    Assertions.assertEquals(OrderStatus.Filled, order.status)
+                    Assertions.assertEquals(1, order.executions.size)
+                    assertAmount(AssetAmount(baseSymbol, "0.00003"), order.executions[0].amount)
+                    assertAmount(AssetAmount(quoteSymbol, "0.999"), order.executions[0].price)
+                    Assertions.assertEquals(ExecutionRole.Taker, order.executions[0].role)
+                }
             }
             assertBalancesMessageReceived(
                 listOf(
@@ -341,12 +350,15 @@ class ArchSettlementTest : OrderBaseTest() {
                     ),
                 ),
             )
-            assertMyOrderUpdatedMessageReceived { msg ->
-                Assertions.assertEquals(OrderStatus.Filled, msg.order.status)
-                Assertions.assertEquals(1, msg.order.executions.size)
-                assertAmount(AssetAmount(baseSymbol, "0.00003"), msg.order.executions[0].amount)
-                assertAmount(AssetAmount(quoteSymbol, "0.999"), msg.order.executions[0].price)
-                Assertions.assertEquals(ExecutionRole.Maker, msg.order.executions[0].role)
+            assertMyOrdersUpdatedMessageReceived { msg ->
+                Assertions.assertEquals(1, msg.orders.size)
+                msg.orders.first().let { order ->
+                    Assertions.assertEquals(OrderStatus.Filled, order.status)
+                    Assertions.assertEquals(1, order.executions.size)
+                    assertAmount(AssetAmount(baseSymbol, "0.00003"), order.executions[0].amount)
+                    assertAmount(AssetAmount(quoteSymbol, "0.999"), order.executions[0].price)
+                    Assertions.assertEquals(ExecutionRole.Maker, order.executions[0].role)
+                }
             }
             assertBalancesMessageReceived(
                 listOf(
@@ -491,7 +503,7 @@ class ArchSettlementTest : OrderBaseTest() {
             makerBitcoinWallet,
         )
         makerWsClient.apply {
-            assertMyLimitOrderCreatedMessageReceived(limitSellOrderApiResponse)
+            assertMyLimitOrdersCreatedMessageReceived(limitSellOrderApiResponse)
             assertLimitsMessageReceived(market, base = BigDecimal("0.59997"), quote = BigDecimal("0"))
         }
 
@@ -504,7 +516,7 @@ class ArchSettlementTest : OrderBaseTest() {
         )
 
         takerWsClient.apply {
-            assertMyMarketOrderCreatedMessageReceived(marketBuyOrderApiResponse)
+            assertMyMarketOrdersCreatedMessageReceived(marketBuyOrderApiResponse)
             assertMyTradesCreatedMessageReceived(
                 listOf(
                     MyExpectedTrade(
@@ -516,12 +528,15 @@ class ArchSettlementTest : OrderBaseTest() {
                     ),
                 ),
             )
-            assertMyOrderUpdatedMessageReceived { msg ->
-                Assertions.assertEquals(OrderStatus.Filled, msg.order.status)
-                Assertions.assertEquals(1, msg.order.executions.size)
-                assertAmount(AssetAmount(baseSymbol, "0.00003"), msg.order.executions[0].amount)
-                assertAmount(AssetAmount(quoteSymbol, "0.999"), msg.order.executions[0].price)
-                Assertions.assertEquals(ExecutionRole.Taker, msg.order.executions[0].role)
+            assertMyOrdersUpdatedMessageReceived { msg ->
+                Assertions.assertEquals(1, msg.orders.size)
+                msg.orders.first().let { order ->
+                    Assertions.assertEquals(OrderStatus.Filled, order.status)
+                    Assertions.assertEquals(1, order.executions.size)
+                    assertAmount(AssetAmount(baseSymbol, "0.00003"), order.executions[0].amount)
+                    assertAmount(AssetAmount(quoteSymbol, "0.999"), order.executions[0].price)
+                    Assertions.assertEquals(ExecutionRole.Taker, order.executions[0].role)
+                }
             }
             assertBalancesMessageReceived(
                 listOf(
@@ -543,12 +558,15 @@ class ArchSettlementTest : OrderBaseTest() {
                     ),
                 ),
             )
-            assertMyOrderUpdatedMessageReceived { msg ->
-                Assertions.assertEquals(OrderStatus.Filled, msg.order.status)
-                Assertions.assertEquals(1, msg.order.executions.size)
-                assertAmount(AssetAmount(baseSymbol, "0.00003"), msg.order.executions[0].amount)
-                assertAmount(AssetAmount(quoteSymbol, "0.999"), msg.order.executions[0].price)
-                Assertions.assertEquals(ExecutionRole.Maker, msg.order.executions[0].role)
+            assertMyOrdersUpdatedMessageReceived { msg ->
+                Assertions.assertEquals(1, msg.orders.size)
+                msg.orders.first().let { order ->
+                    Assertions.assertEquals(OrderStatus.Filled, order.status)
+                    Assertions.assertEquals(1, order.executions.size)
+                    assertAmount(AssetAmount(baseSymbol, "0.00003"), order.executions[0].amount)
+                    assertAmount(AssetAmount(quoteSymbol, "0.999"), order.executions[0].price)
+                    Assertions.assertEquals(ExecutionRole.Maker, order.executions[0].role)
+                }
             }
             assertBalancesMessageReceived(
                 listOf(

--- a/integrationtests/src/test/kotlin/xyz/funkybit/integrationtests/exchange/MarketTradesBroadcastingTest.kt
+++ b/integrationtests/src/test/kotlin/xyz/funkybit/integrationtests/exchange/MarketTradesBroadcastingTest.kt
@@ -22,8 +22,8 @@ import xyz.funkybit.integrationtests.utils.AssetAmount
 import xyz.funkybit.integrationtests.utils.TestApiClient
 import xyz.funkybit.integrationtests.utils.assertBalancesMessageReceived
 import xyz.funkybit.integrationtests.utils.assertMarketTradesCreatedMessageReceived
-import xyz.funkybit.integrationtests.utils.assertMyOrderCreatedMessageReceived
-import xyz.funkybit.integrationtests.utils.assertMyOrderUpdatedMessageReceived
+import xyz.funkybit.integrationtests.utils.assertMyOrdersCreatedMessageReceived
+import xyz.funkybit.integrationtests.utils.assertMyOrdersUpdatedMessageReceived
 import xyz.funkybit.integrationtests.utils.assertMyTradesCreatedMessageReceived
 import xyz.funkybit.integrationtests.utils.blocking
 import xyz.funkybit.integrationtests.utils.subscribeToMarketTrades
@@ -94,7 +94,9 @@ class MarketTradesBroadcastingTest : OrderBaseTest() {
         )
 
         assertEquals(3, createBatchLimitOrders.createdOrders.count())
-        repeat(3) { makerWsClient.assertMyOrderCreatedMessageReceived() }
+        makerWsClient.assertMyOrdersCreatedMessageReceived {
+            assertEquals(3, it.orders.size)
+        }
 
         val batchOrderResponse = makerApiClient.batchOrders(
             BatchOrdersApiRequest(
@@ -133,8 +135,10 @@ class MarketTradesBroadcastingTest : OrderBaseTest() {
         assertEquals(1, batchOrderResponse.canceledOrders.count { it.requestStatus == RequestStatus.Accepted })
         assertEquals(1, batchOrderResponse.canceledOrders.count { it.requestStatus == RequestStatus.Rejected })
 
-        repeat(3) { makerWsClient.assertMyOrderCreatedMessageReceived() }
-        makerWsClient.assertMyOrderUpdatedMessageReceived()
+        makerWsClient.assertMyOrdersCreatedMessageReceived {
+            assertEquals(3, it.orders.size)
+        }
+        makerWsClient.assertMyOrdersUpdatedMessageReceived()
 
         assertEquals(5, makerApiClient.listOrders(listOf(OrderStatus.Open), null).orders.size)
 
@@ -149,11 +153,11 @@ class MarketTradesBroadcastingTest : OrderBaseTest() {
         )
 
         takerWsClient.apply {
-            assertMyOrderCreatedMessageReceived()
+            assertMyOrdersCreatedMessageReceived()
             assertMyTradesCreatedMessageReceived { msg ->
                 assertEquals(5, msg.trades.size)
             }
-            assertMyOrderUpdatedMessageReceived()
+            assertMyOrdersUpdatedMessageReceived()
             assertBalancesMessageReceived()
         }
 
@@ -161,7 +165,9 @@ class MarketTradesBroadcastingTest : OrderBaseTest() {
             assertMyTradesCreatedMessageReceived { msg ->
                 assertEquals(5, msg.trades.size)
             }
-            repeat(5) { assertMyOrderUpdatedMessageReceived() }
+            assertMyOrdersUpdatedMessageReceived { msg ->
+                assertEquals(5, msg.orders.size)
+            }
             assertBalancesMessageReceived()
         }
 
@@ -209,7 +215,9 @@ class MarketTradesBroadcastingTest : OrderBaseTest() {
             ),
         )
 
-        repeat(2) { makerWsClient.assertMyOrderCreatedMessageReceived() }
+        makerWsClient.assertMyOrdersCreatedMessageReceived {
+            assertEquals(2, it.orders.size)
+        }
 
         takerApiClient.createMarketOrder(
             market,
@@ -219,11 +227,11 @@ class MarketTradesBroadcastingTest : OrderBaseTest() {
         )
 
         takerWsClient.apply {
-            assertMyOrderCreatedMessageReceived()
+            assertMyOrdersCreatedMessageReceived()
             assertMyTradesCreatedMessageReceived { msg ->
                 assertEquals(2, msg.trades.size)
             }
-            assertMyOrderUpdatedMessageReceived()
+            assertMyOrdersUpdatedMessageReceived()
             assertBalancesMessageReceived()
         }
 
@@ -231,7 +239,9 @@ class MarketTradesBroadcastingTest : OrderBaseTest() {
             assertMyTradesCreatedMessageReceived { msg ->
                 assertEquals(2, msg.trades.size)
             }
-            repeat(2) { assertMyOrderUpdatedMessageReceived() }
+            assertMyOrdersUpdatedMessageReceived { msg ->
+                assertEquals(2, msg.orders.size)
+            }
             assertBalancesMessageReceived()
         }
 

--- a/integrationtests/src/test/kotlin/xyz/funkybit/integrationtests/testnetchallenge/TestnetChallengeTest.kt
+++ b/integrationtests/src/test/kotlin/xyz/funkybit/integrationtests/testnetchallenge/TestnetChallengeTest.kt
@@ -56,7 +56,7 @@ import xyz.funkybit.integrationtests.utils.Faucet
 import xyz.funkybit.integrationtests.utils.TestApiClient
 import xyz.funkybit.integrationtests.utils.Wallet
 import xyz.funkybit.integrationtests.utils.assertError
-import xyz.funkybit.integrationtests.utils.assertMyLimitOrderCreatedMessageReceived
+import xyz.funkybit.integrationtests.utils.assertMyLimitOrdersCreatedMessageReceived
 import xyz.funkybit.integrationtests.utils.signAuthorizeBitcoinWalletRequest
 import java.math.BigDecimal
 import java.math.BigInteger
@@ -206,7 +206,7 @@ class TestnetChallengeTest : OrderBaseTest() {
         // once the user places an order, they shouldn't get the Enrolled card
         val response = trader.a.createLimitOrder(btcUsdcMarket, OrderSide.Buy, BigDecimal.ONE, BigDecimal.valueOf(25), trader.w)
         trader.ws.apply {
-            assertMyLimitOrderCreatedMessageReceived(response)
+            assertMyLimitOrdersCreatedMessageReceived(response)
         }
         cards = trader.a.getCards()
         assertEquals(4, cards.size)

--- a/mocker/src/main/kotlin/xyz/funkybit/mocker/core/Maker.kt
+++ b/mocker/src/main/kotlin/xyz/funkybit/mocker/core/Maker.kt
@@ -7,8 +7,6 @@ import xyz.funkybit.apps.api.model.Market
 import xyz.funkybit.apps.api.model.Order
 import xyz.funkybit.apps.api.model.OrderAmount
 import xyz.funkybit.apps.api.model.websocket.Balances
-import xyz.funkybit.apps.api.model.websocket.MyOrderCreated
-import xyz.funkybit.apps.api.model.websocket.MyOrderUpdated
 import xyz.funkybit.apps.api.model.websocket.MyOrders
 import xyz.funkybit.apps.api.model.websocket.Prices
 import xyz.funkybit.apps.api.model.websocket.Publishable
@@ -41,6 +39,8 @@ import kotlin.random.Random
 import kotlinx.datetime.Clock
 import org.knowm.xchart.SwingWrapper
 import org.knowm.xchart.XYChartBuilder
+import xyz.funkybit.apps.api.model.websocket.MyOrdersCreated
+import xyz.funkybit.apps.api.model.websocket.MyOrdersUpdated
 import xyz.funkybit.core.utils.PriceFeed
 import xyz.funkybit.integrationtests.utils.WalletKeyPair
 
@@ -161,11 +161,11 @@ class Maker(
                 logger.info { "$id: received balance update ${message.balances}" }
             }
 
-            is MyOrders, is MyOrderCreated, is MyOrderUpdated -> {
+            is MyOrders, is MyOrdersCreated, is MyOrdersUpdated -> {
                 val orders = when (message) {
                     is MyOrders -> message.orders
-                    is MyOrderCreated -> listOf(message.order)
-                    is MyOrderUpdated -> listOf(message.order)
+                    is MyOrdersCreated -> message.orders
+                    is MyOrdersUpdated -> message.orders
                     else -> emptyList()
                 }
                 orders.forEach { order ->

--- a/mocker/src/main/kotlin/xyz/funkybit/mocker/core/Taker.kt
+++ b/mocker/src/main/kotlin/xyz/funkybit/mocker/core/Taker.kt
@@ -5,8 +5,6 @@ import xyz.funkybit.apps.api.model.Market
 import xyz.funkybit.apps.api.model.Order
 import xyz.funkybit.apps.api.model.OrderAmount
 import xyz.funkybit.apps.api.model.websocket.Balances
-import xyz.funkybit.apps.api.model.websocket.MyOrderCreated
-import xyz.funkybit.apps.api.model.websocket.MyOrderUpdated
 import xyz.funkybit.apps.api.model.websocket.MyOrders
 import xyz.funkybit.apps.api.model.websocket.Prices
 import xyz.funkybit.apps.api.model.websocket.Publishable
@@ -14,7 +12,6 @@ import xyz.funkybit.apps.api.model.websocket.SubscriptionTopic
 import xyz.funkybit.apps.api.model.websocket.MyTradesCreated
 import xyz.funkybit.apps.api.model.websocket.MyTradesUpdated
 import xyz.funkybit.apps.api.model.websocket.MyTrades
-import xyz.funkybit.core.model.EvmAddress
 import xyz.funkybit.core.model.EvmSignature
 import xyz.funkybit.core.model.db.MarketId
 import xyz.funkybit.core.model.db.OHLCDuration
@@ -35,6 +32,8 @@ import kotlinx.datetime.Clock
 import okhttp3.WebSocket
 import org.web3j.crypto.ECKeyPair
 import org.web3j.crypto.Keys
+import xyz.funkybit.apps.api.model.websocket.MyOrdersCreated
+import xyz.funkybit.apps.api.model.websocket.MyOrdersUpdated
 import xyz.funkybit.integrationtests.utils.WalletKeyPair
 
 class Taker(
@@ -138,11 +137,11 @@ class Taker(
                 logger.info { "$id: received balance update ${message.balances}" }
             }
 
-            is MyOrders, is MyOrderCreated, is MyOrderUpdated -> {
+            is MyOrders, is MyOrdersCreated, is MyOrdersUpdated -> {
                 val orders = when (message) {
                     is MyOrders -> message.orders
-                    is MyOrderCreated -> listOf(message.order)
-                    is MyOrderUpdated -> listOf(message.order)
+                    is MyOrdersCreated -> message.orders
+                    is MyOrdersUpdated -> message.orders
                     else -> emptyList()
                 }
                 orders.forEach { order ->

--- a/sequencer/src/main/kotlin/xyz/funkybit/sequencer/apps/services/SequencerResponseProcessorService.kt
+++ b/sequencer/src/main/kotlin/xyz/funkybit/sequencer/apps/services/SequencerResponseProcessorService.kt
@@ -420,7 +420,7 @@ object SequencerResponseProcessorService {
             // instruct exposed to expect result set
             explicitStatementType = StatementType.SELECT,
         ) { rs ->
-            // remove all entities updated directly in the database from the entity cache
+            // remove all entities that were updated directly in the database from the entity cache
             val entityCache = TransactionManager.current().entityCache
             while (rs.next()) {
                 val entityId = EntityID(OrderId(rs.getString(1)), OrderTable)

--- a/web-ui/src/components/Screens/HomeScreen/OrdersAndTradesWidget/OrdersAndTradesWidget.tsx
+++ b/web-ui/src/components/Screens/HomeScreen/OrdersAndTradesWidget/OrdersAndTradesWidget.tsx
@@ -51,20 +51,21 @@ export default function OrdersAndTradesWidget({
       (message: Publishable) => {
         if (message.type === 'MyOrders') {
           setOrders(message.orders)
-        } else if (message.type === 'MyOrderCreated') {
+        } else if (message.type === 'MyOrdersCreated') {
           setOrders(
             produce((draft) => {
-              draft.unshift(message.order)
+              message.orders.forEach((order) => draft.unshift(order))
             })
           )
-        } else if (message.type === 'MyOrderUpdated') {
+        } else if (message.type === 'MyOrdersUpdated') {
           setOrders(
             produce((draft) => {
-              const updatedOrder = message.order
-              const index = draft.findIndex(
-                (order) => order.id === updatedOrder.id
-              )
-              if (index !== -1) draft[index] = updatedOrder
+              message.orders.forEach((updatedOrder) => {
+                const index = draft.findIndex(
+                  (order) => order.id === updatedOrder.id
+                )
+                if (index !== -1) draft[index] = updatedOrder
+              })
             })
           )
         } else if (message.type === 'MyTrades') {

--- a/web-ui/src/components/Screens/HomeScreen/swap/SwapInternals.tsx
+++ b/web-ui/src/components/Screens/HomeScreen/swap/SwapInternals.tsx
@@ -293,8 +293,8 @@ export function SwapInternals({
           }
         } else if (message.type === 'Balances') {
           setBalances(message.balances)
-        } else if (message.type === 'MyOrderUpdated') {
-          setLastOrder(message.order)
+        } else if (message.type === 'MyOrdersUpdated') {
+          setLastOrder(message.orders[0])
         }
       },
       [market, markets, quoteSymbol, baseSymbol]

--- a/web-ui/src/websocketMessages.ts
+++ b/web-ui/src/websocketMessages.ts
@@ -112,17 +112,17 @@ export const BalancesSchema = z.object({
 })
 export type Balances = z.infer<typeof BalancesSchema>
 
-export const MyOrderCreatedSchema = z.object({
-  type: z.literal('MyOrderCreated'),
-  order: OrderSchema
+export const MyOrdersCreatedSchema = z.object({
+  type: z.literal('MyOrdersCreated'),
+  orders: z.array(OrderSchema)
 })
-export type MyOrderCreated = z.infer<typeof MyOrderCreatedSchema>
+export type MyOrdersCreated = z.infer<typeof MyOrdersCreatedSchema>
 
-export const MyOrderUpdatedSchema = z.object({
-  type: z.literal('MyOrderUpdated'),
-  order: OrderSchema
+export const MyOrdersUpdatedSchema = z.object({
+  type: z.literal('MyOrdersUpdated'),
+  orders: z.array(OrderSchema)
 })
-export type MyOrderUpdated = z.infer<typeof MyOrderUpdatedSchema>
+export type MyOrdersUpdated = z.infer<typeof MyOrdersUpdatedSchema>
 
 export const MarketLimitsSchema = z
   .tuple([
@@ -160,8 +160,8 @@ export const PublishableSchema = z.discriminatedUnion('type', [
   MyTradesUpdatedSchema,
   MyOrdersSchema,
   BalancesSchema,
-  MyOrderCreatedSchema,
-  MyOrderUpdatedSchema,
+  MyOrdersCreatedSchema,
+  MyOrdersUpdatedSchema,
   LimitsSchema
 ])
 export type Publishable = z.infer<typeof PublishableSchema>


### PR DESCRIPTION
Includes:
 - CHAIN-275 - send batch order updates in a single message over the websocket to reduce overhead
 - CHAIN-593 - process order updates in the sequencer response processor using SQL batch
 - CHAIN-155 - update OHLC records in SQL batch
 - CHAIN-594 - limit max order batch size