### PR TITLE
Chain 275/handle maker batch max size

### DIFF
--- a/mocker/src/main/kotlin/xyz/funkybit/mocker/Main.kt
+++ b/mocker/src/main/kotlin/xyz/funkybit/mocker/Main.kt
@@ -122,7 +122,7 @@ fun main() {
     timer.cancel()
 }
 
-fun startMaker(market: Market, marketPriceOverride: BigDecimal?, liquidityPlacement: LiquidityPlacement, baseAssetAmount: BigDecimal, quoteAssetAmount: BigDecimal, keyPair: WalletKeyPair = WalletKeyPair.EVM.generate(), usePriceFeed: Boolean = false): Maker {
+fun startMaker(market: Market, marketPriceOverride: BigDecimal?, liquidityPlacement: LiquidityPlacement, baseAssetAmount: BigDecimal, quoteAssetAmount: BigDecimal, keyPair: WalletKeyPair = WalletKeyPair.EVM.generate(), usePriceFeed: Boolean = false, maxOrdersBatchSize: Int = 100): Maker {
     val baseAssetBtc = market.baseSymbol.value.startsWith("BTC")
     val quoteAssetBtc = market.quoteSymbol.value.startsWith("BTC")
     val baseAsset = market.baseSymbol.value to baseAssetAmount.toFundamentalUnits(market.baseDecimals)
@@ -146,7 +146,8 @@ fun startMaker(market: Market, marketPriceOverride: BigDecimal?, liquidityPlacem
             else -> mapOf(baseAsset, quoteAsset)
         },
         keyPair = keyPair,
-        usePriceFeed = usePriceFeed
+        usePriceFeed = usePriceFeed,
+        maxOrdersBatchSize = maxOrdersBatchSize
     )
     maker.start()
     return maker

--- a/mocker/src/main/kotlin/xyz/funkybit/mocker/MockerAppMain.kt
+++ b/mocker/src/main/kotlin/xyz/funkybit/mocker/MockerAppMain.kt
@@ -26,9 +26,7 @@ import org.http4k.server.Netty
 import org.http4k.server.PolyHandler
 import org.http4k.server.ServerConfig
 import org.http4k.server.asServer
-import org.web3j.crypto.ECKeyPair
 import org.web3j.crypto.Keys
-import org.web3j.utils.Numeric
 import xyz.funkybit.integrationtests.utils.WalletKeyPair
 
 fun main() {
@@ -147,7 +145,8 @@ class MockerApp(
                         baseAssetAmount = params.initialBaseBalance * BigDecimal(100),
                         quoteAssetAmount = params.initialBaseBalance * params.priceBaseline * BigDecimal(100),
                         keyPair = WalletKeyPair.EVM.fromPrivateKeyHex(params.makerPrivateKeyHex),
-                        usePriceFeed = System.getenv("MAKER_USE_PRICE_FEED")?.toBoolean() ?: false
+                        usePriceFeed = System.getenv("MAKER_USE_PRICE_FEED")?.toBoolean() ?: false,
+                        maxOrdersBatchSize = System.getenv("BATCH_ORDERS_MAX_SIZE")?.toIntOrNull() ?: 100
                     )
                 )
             }

--- a/mocker/src/main/kotlin/xyz/funkybit/mocker/core/Maker.kt
+++ b/mocker/src/main/kotlin/xyz/funkybit/mocker/core/Maker.kt
@@ -349,7 +349,7 @@ class Maker(
             ).onLeft {
                 logger.warn { "$id could not apply batch: ${it.error?.message}" }
             }.onRight {
-                logger.info { "$id: applied update batch: created ${createOrders.size}, cancelled ${cancelOrders.size}" }
+                logger.info { "$id: applied update batch: created ${createOrdersChunk.size}, cancelled ${cancelOrdersChunk.size}" }
             }
         }
     }


### PR DESCRIPTION
when mocker reacts on trade to send new batch too quickly it can happen that order created messages did not arrive yet. As a result for the next batch number of orders to cancel is higher and batch size can exceed max size